### PR TITLE
1.0.17 - subscription form with spam protection and test suite

### DIFF
--- a/1.0.17-subscription-form.md
+++ b/1.0.17-subscription-form.md
@@ -62,7 +62,7 @@ flowchart TD
 ## Gutenberg Block
 
 - Block name: `mawiblah/subscription-form`
-- Block attribute: `audiences` (array of audienceHash strings)
+- Block attribute: `audienceHashes` (array of audienceHash strings)
 - Editor UI: multi-select dropdown populated from `getAllAudiences()`, displays audience name, stores hash
 - Renders via `render_callback` — same output as shortcode (no duplication)
 - No build step — registered with `wp.blocks.registerBlockType` in vanilla JS

--- a/1.0.17-subscription-form.md
+++ b/1.0.17-subscription-form.md
@@ -1,0 +1,722 @@
+# 1.0.17 — Subscription Form
+
+## Overview
+
+Native subscription form embeddable anywhere via a WordPress shortcode or Gutenberg block. Supports multiple audiences, honeypot + optional reCAPTCHA v3 spam protection, and a re-subscribe confirmation flow for previously unsubscribed users.
+
+---
+
+## User Flow
+
+```mermaid
+flowchart TD
+    A[Editor adds block or shortcode\naudiencces='hash1,hash2'] --> B[Page renders HTML form\nemail input · hidden honeypot · submit]
+    B --> C{reCAPTCHA v3\nenabled in Settings?}
+    C -- Yes --> D[Load reCAPTCHA v3 script\nattach token on submit]
+    C -- No --> E[Plain form submit]
+    D & E --> F[JS POST /wp-json/mawiblah/v1/subscribe\nemail · audienceHashes · honeypot · recaptchaToken]
+
+    F --> G{Honeypot\nhas a value?}
+    G -- Yes --> H[Silently return success\nbot rejected]
+    G -- No --> I{reCAPTCHA\nenabled?}
+    I -- Yes --> J[Verify token via\nGoogle reCAPTCHA API]
+    J -- Score too low --> K[Return error:\nverification failed]
+    J -- Score OK --> L{Valid\nemail format?}
+    I -- No --> L
+    L -- No --> M[Return error:\ninvalid email]
+    L -- Yes --> N{Subscriber\nexists?}
+
+    N -- No --> O[Create subscriber\ngenerate subscriberHash]
+    O --> P[Add to all\ntarget audiences]
+    P --> Q[Return success\nnewly subscribed]
+
+    N -- Yes, unsubed --> R[Generate resubToken\nor reuse existing unsubToken]
+    R --> S[Send re-subscribe\nconfirmation email with link\naudiences encoded in URL]
+    S --> T[Return success\ncheck inbox to confirm]
+
+    N -- Yes, active --> U{Already in\nall target audiences?}
+    U -- Yes --> V[Return success\nsilently — no error]
+    U -- No --> W[Add to missing\naudiences only]
+    W --> X[Return success]
+
+    H & K & M & Q & T & V & X --> Y[JS swaps form\nfor success or error message]
+
+    T -.->|user clicks link| Z[GET confirmation URL\nresubToken · subscriberHash · audienceHashes]
+    Z --> AA{resubToken\nvalid?}
+    AA -- No --> AB[Show: invalid or\nexpired link page]
+    AA -- Yes --> AC[Clear unsubed flag\nrestore unsub_time=null\nadd to target audiences]
+    AC --> AD[Show: resubscribed\nsuccess page]
+```
+
+---
+
+## Shortcode
+
+```
+[mawiblah_subscribe_form audiences="hash1,hash2"]
+```
+
+- `audiences` — comma-separated `audienceHash` values (plural, matches campaign field naming)
+- Omitting `audiences` subscribes without assigning to any audience
+
+## Gutenberg Block
+
+- Block name: `mawiblah/subscription-form`
+- Block attribute: `audiences` (array of audienceHash strings)
+- Editor UI: multi-select dropdown populated from `getAllAudiences()`, displays audience name, stores hash
+- Renders via `render_callback` — same output as shortcode (no duplication)
+- No build step — registered with `wp.blocks.registerBlockType` in vanilla JS
+
+---
+
+## HTML Structure & CSS Classes
+
+```html
+<div class="mawiblah-subscribe-form">
+
+  <form class="mawiblah-subscribe-form__form">
+    <!-- honeypot: hidden via inline style so it survives theme CSS resets -->
+    <input type="text" name="website" style="display:none" tabindex="-1" autocomplete="off" />
+
+    <div class="mawiblah-subscribe-form__field">
+      <label class="mawiblah-subscribe-form__label" for="mawiblah-email">Email</label>
+      <input class="mawiblah-subscribe-form__input"
+             type="email" id="mawiblah-email" name="email"
+             placeholder="your@email.com" required />
+    </div>
+
+    <div class="mawiblah-subscribe-form__actions">
+      <button class="mawiblah-subscribe-form__button" type="submit">Subscribe</button>
+    </div>
+  </form>
+
+  <div class="mawiblah-subscribe-form__message mawiblah-subscribe-form__message--success" hidden></div>
+  <div class="mawiblah-subscribe-form__message mawiblah-subscribe-form__message--error" hidden></div>
+
+</div>
+```
+
+**State modifiers added by JS to the wrapper:**
+- `mawiblah-subscribe-form--loading` — while fetch is in flight
+- `mawiblah-subscribe-form--submitted` — after success (theme can hide the form)
+
+**CSS philosophy:** box-model only (display, width, margin) — no colours, no fonts, no borders. Enqueued only on pages that contain the shortcode or block.
+
+---
+
+## REST Endpoint
+
+`POST /wp-json/mawiblah/v1/subscribe` — public, no auth required
+
+**Request:**
+```json
+{
+  "email": "user@example.com",
+  "audienceHashes": ["hash1", "hash2"],
+  "honeypot": "",
+  "recaptchaToken": "..."
+}
+```
+
+**Responses:**
+```json
+{ "status": "ok",    "message": "You are now subscribed!" }
+{ "status": "ok",    "message": "Check your inbox to confirm your subscription." }
+{ "status": "error", "message": "Invalid email address." }
+{ "status": "error", "message": "Verification failed. Please try again." }
+```
+
+---
+
+## Audience Hash
+
+Audiences (taxonomy terms) currently have no hash. A new `audienceHash` (MD5 of `term_id`) will be added, consistent with `subscriberHash` and `campaignHash`.
+
+- Generated lazily in `appendAudienceMeta()` on first access, stored via `add_term_meta`
+- Never changes (derived from immutable term_id)
+- Preferred over slug (slug is mutable — editor rename would silently break shortcodes)
+
+---
+
+## Re-subscribe Confirmation
+
+Triggered when a submitted email is found with `unsubed = true`.
+
+- Reuses existing `unsubToken` stored on the subscriber (no new meta field needed)
+- Sends a confirmation email with a link containing `resubToken`, `subscriberHash`, `audienceHashes`
+- URL handler added to `SubscriptionForm::init()` (mirrors `Unsubscribe::init()` pattern)
+- On confirmation: clears `unsubed` flag, nulls `unsub_time`, adds to target audiences
+- Invalid/missing token → shows error page
+
+---
+
+## Spam Protection
+
+### Honeypot (always active)
+- Hidden `<input name="website">` rendered inline-hidden
+- Server rejects silently if value is non-empty (returns success to fool bots)
+
+### reCAPTCHA v3 (optional)
+- Enabled via Settings — requires site key + secret key
+- JS loads `https://www.google.com/recaptcha/api.js` only when enabled
+- Token attached to form submission, verified server-side via Google API
+- Score threshold: `0.5` (configurable via constant `MAWIBLAH_RECAPTCHA_THRESHOLD`)
+
+---
+
+## Settings — New Section
+
+Added to `config/sections.json`:
+
+```json
+{
+  "id": "mawiblah-recaptcha",
+  "title": "reCAPTCHA v3 (Subscription Form)",
+  "description": "Optional Google reCAPTCHA v3 for the subscription form. Leave disabled to rely on honeypot only.",
+  "fields": [
+    {
+      "id": "mawiblah-recaptcha-enabled",
+      "title": "Enable reCAPTCHA v3",
+      "type": "select",
+      "value": "",
+      "default_value": "disabled",
+      "options": [
+        { "value": "disabled", "title": "Disabled" },
+        { "value": "enabled",  "title": "Enabled" }
+      ]
+    },
+    {
+      "id": "mawiblah-recaptcha-site-key",
+      "title": "Site Key",
+      "type": "text",
+      "value": "",
+      "placeholder": "6Lc...",
+      "default_value": ""
+    },
+    {
+      "id": "mawiblah-recaptcha-secret-key",
+      "title": "Secret Key",
+      "type": "text",
+      "value": "",
+      "placeholder": "6Lc...",
+      "default_value": ""
+    }
+  ]
+}
+```
+
+New getters in `Settings.php`:
+- `Settings::recaptchaEnabled(): bool`
+- `Settings::recaptchaSiteKey(): string`
+- `Settings::recaptchaSecretKey(): string`
+
+---
+
+## Files
+
+### New
+| File | Purpose |
+|---|---|
+| `classes/SubscriptionForm.php` | REST endpoint, honeypot check, reCAPTCHA verify, subscribe logic, resubscribe confirmation handler |
+| `templates/subscription-form/form.php` | HTML form template |
+| `templates/subscription-form/resubscribe-confirm.php` | Re-subscribe confirmation success page |
+| `templates/subscription-form/resubscribe-invalid.php` | Invalid/expired token page |
+| `assets/css/subscription-form.css` | Minimal front-end styles (box-model only) |
+| `assets/js/subscription-form.js` | Fetch submit, reCAPTCHA token attach, DOM swap |
+| `assets/js/block/subscription-form.js` | Gutenberg block registration (vanilla JS) |
+
+### Modified
+| File | Change |
+|---|---|
+| `mawiblah.php` | `require` new class, version bump `1.0.16` → `1.0.17` |
+| `classes/ShortCodes.php` | Register `[mawiblah_subscribe_form]` |
+| `classes/Init.php` | Register REST route `/subscribe`, `register_block_type()`, enqueue front-end assets conditionally |
+| `classes/Settings.php` | Add `recaptchaEnabled()`, `recaptchaSiteKey()`, `recaptchaSecretKey()` |
+| `classes/Subscribers.php` | Add `audienceHash` to `appendAudienceMeta()` (lazy generate + persist) |
+| `config/sections.json` | Add reCAPTCHA section |
+
+---
+
+## Documentation Updates (last step)
+
+| File | Change |
+|---|---|
+| `mawiblah.php` | Version bump to `1.0.17` |
+| `README.md` | Add feature bullet, update comparison table Form Integration row, add `### --- 1.0.17 ---` changelog entry |
+| `readme.txt` | Bump `Stable tag`, add to Key Features, add `= 1.0.17 =` changelog entry |
+| `DOCUMENTATION.md` | Add Subscription Form section: shortcode usage, block usage, class names, settings keys, REST shape |
+
+---
+
+## Test Coverage Review
+
+### Currently covered
+
+Only 4 methods in `Campaigns`, all in one auto-running flat block:
+
+| Class | Method | Covered |
+|---|---|---|
+| Campaigns | `addCampaign` | ✅ |
+| Campaigns | `getCampaign` | ✅ |
+| Campaigns | `getCampaigns` | ✅ |
+| Campaigns | `deleteCampaign` | ✅ |
+
+Everything else is untested.
+
+---
+
+### Not covered — by priority
+
+#### 🔴 High (core business logic, user-facing risk)
+
+**Campaigns**
+- `validateCampaign` — validation rules for title/subject/audiences/template
+- `testStart / testFinish / testApprove / testReset` — workflow state transitions
+- `campaignStart / campaignFinish` — send lifecycle, guard against double-start
+- `updateCounters / getCounters` — counter accuracy across sent/failed/skipped/unsubed
+- `incrementNewlyUnsubed` — unsubscribe attribution per campaign
+- `lockTemplate / fillTemplate` — placeholder replacement: `{campaignHash}`, `{subscriberHash}`, `{email}`
+- `linkClicked` — triple-count logic (total / unique-per-session / unique-per-user)
+
+**Subscribers**
+- `addSubscriber` — creation, hash generation, duplicate guard
+- `getSubscriber / getSubscriberById / getSubscriberBySubscriberHash` — lookup paths
+- `appendMeta` — `audienceHash` lazy generation + idempotency (new)
+- `addSubscriberToAudience` — taxonomy assignment + `unsubed` sync side-effect
+- `unsub` — token check, flag set, audience assignment, feedback storage
+- `isEmailSent` — prevents double-send
+- `isTester` — gates test-mode sending
+- `getUnsubToken` — lazy generation + persistence
+- `unsubedAudience / testerAudience` — special audience lookups
+
+**Unsubscribe flow**
+- `Unsubscribe::unsubscribe()` — subscriber found vs not found, GravityForms fallback, token generation
+- `Unsubscribe::unsubscribeAprooved()` — token valid, already unsubed, campaign counter increment
+
+**RestRoutes**
+- `sendEmail` — all 7 skip/send paths: unsubscribed, already sent, do-not-disturb, not tester in test mode, email sending disabled, template failure, success, failure
+
+#### 🟡 Medium (correctness matters, lower change frequency)
+
+**Helpers**
+- `generateSubscriberHash / generateCampaignHash` — deterministic, consistent output
+- `trackingParams` — URL encoding, param merging
+- `emailSendingStats` — correct shape returned for each path
+
+**Visits**
+- `visit()` — session-based deduplication: `linksClickedTotal` always incremented, `linksClicked` only once per URL per session, `uniqueUserClicks` only once per subscriber per campaign
+
+**Subscribers**
+- `validateAudiences` — rejects invalid term IDs, rejects empty array
+- `getSubscriberGrowthStats` — 12-month bucketing logic
+- `getUnsubscribeReasons` — returns correct structure
+
+**Campaigns**
+- `getCampaignByHash` — lookup by `campaignHash` not post ID
+- `getLastCampaigns` — ordering + limit respected
+- `getStatsForCampaign / getConversionStatsForCampaign` — stat shapes correct
+
+#### 🟢 Low (infrastructure, rarely changes)
+
+**Settings**
+- `getOption` — returns saved value, falls back to `default_value`
+- `sendEmails / dontDisturbThreshold` — correct option keys read
+
+**Migrations**
+- `migrateTo1016` — `subscriberId` → `subscriberHash` rename, no data loss, idempotent (safe to run twice)
+
+**GravityForms**
+- Skip — relies on GravityForms being installed; mock-heavy, low value
+
+**Logs / Renderer / Actions**
+- Skip — output/rendering classes, not logic
+
+---
+
+### Suggested new scenarios (additions to `Tests.php` + PHPUnit)
+
+| Scenario | Layer 1 (in-browser) | Layer 2 (PHPUnit) |
+|---|---|---|
+| `campaignScenario` | refactor existing | mirror as PHPUnit |
+| `campaignWorkflowScenario` | test/start/finish/approve/reset | ✅ |
+| `campaignCountersScenario` | updateCounters, getCounters, incrementNewlyUnsubed | ✅ |
+| `campaignTemplateScenario` | lockTemplate, fillTemplate placeholder replacement | ✅ |
+| `subscriberScenario` | add, get, hash generation, audience assignment | ✅ |
+| `unsubscribeScenario` | full token flow, already-unsubed guard | ✅ |
+| `clickTrackingScenario` | triple-count logic via Visits::visit() | ✅ |
+| `subscriptionFormScenario` | all 9 new form cases | ✅ |
+| `migrationScenario` | migrateTo1016 idempotency | PHPUnit only |
+
+---
+
+## Testing Strategy
+
+Three layers, all opt-in (button-triggered, never auto-run on page load).
+
+---
+
+### Layer 1 — In-browser integration tests (Tests.php refactor)
+
+**Current problems to fix first:**
+- `Tests::tests()` auto-fires on every page load — needs to move behind a `?run=` param check
+- Everything is one flat method — needs splitting into named scenarios
+- `tests.php` template calls `Tests::tests()` directly — replace with a scenario button grid
+
+**New structure:**
+
+`tests.php` template renders a button per scenario. Clicking a button reloads the page with `?run=scenario-name`. The template checks for `?run=` and fires only that scenario. No `?run=` → just show the buttons and the settings table.
+
+```
+?page=mawiblah-tests                    → show buttons + settings table
+?page=mawiblah-tests&run=campaigns      → run campaign scenario only
+?page=mawiblah-tests&run=subscribers    → run subscriber scenario only
+?page=mawiblah-tests&run=subscription-form → run subscription form scenario
+```
+
+**Existing scenarios to extract from `Tests::tests()`:**
+- `Tests::campaignScenario()` — create / find / count / delete campaigns (existing logic)
+
+**New scenarios for subscription form:**
+- `Tests::subscriberScenario()` — create subscriber, check audienceHash generation, cleanup
+- `Tests::subscriptionFormScenario()` — covers:
+  - New email → subscriber created, added to correct audiences ✓
+  - Same email again → silent success, no duplicate ✓
+  - Honeypot filled → subscriber NOT created ✓
+  - Invalid email format → subscriber NOT created ✓
+  - Unsubscribed email → no re-subscribe yet, re-confirm email triggered ✓
+  - Re-subscribe token valid → `unsubed` cleared, added to audiences ✓
+  - Re-subscribe token invalid → rejected ✓
+  - Multiple audiences → subscriber added to all target audiences ✓
+  - Partial overlap → subscriber added only to missing audiences ✓
+
+Each scenario: creates its own test data, asserts, cleans up. Self-contained.
+
+---
+
+### Layer 2 — PHPUnit integration tests
+
+New files required:
+```
+composer.json                  — require phpunit/phpunit + yoast/wp-test-utils or brain/monkey
+phpunit.xml.dist               — bootstrap, test suite config
+tests/bootstrap.php            — load WP environment
+tests/Integration/
+    SubscriptionFormTest.php   — mirrors Layer 1 scenarios but as proper PHPUnit assertions
+    SubscriberAudienceHashTest.php — audienceHash generation + idempotency
+```
+
+Tests run against the real WordPress database (integration, not unit). Same scenarios as Layer 1 but expressed as `assertSame`, `assertTrue`, `assertCount` etc. — runnable in CI via `composer test`.
+
+**`composer.json` deps:**
+```json
+{
+  "require-dev": {
+    "phpunit/phpunit": "^10",
+    "wp-phpunit/wp-phpunit": "^6"
+  },
+  "scripts": {
+    "test": "phpunit"
+  }
+}
+```
+
+---
+
+### Layer 3 — Jest (frontend JS unit tests)
+
+New files required:
+```
+package.json                            — jest + jsdom
+tests/js/subscription-form.test.js     — covers frontend JS behaviour
+```
+
+**Scenarios:**
+- Form submit sends correct POST payload (email, audienceHashes, honeypot field empty)
+- Honeypot field is present in DOM but not user-visible
+- Success response → form hidden, success message shown
+- Error response → error message shown, form stays visible
+- Loading state → button disabled while fetch in flight
+- reCAPTCHA token attached to payload when grecaptcha is available
+
+**`package.json` deps:**
+```json
+{
+  "devDependencies": {
+    "jest": "^29",
+    "jest-environment-jsdom": "^29"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}
+```
+
+---
+
+## Files — Testing additions
+
+### New
+| File | Purpose |
+|---|---|
+| `composer.json` | PHPUnit + wp-phpunit deps |
+| `phpunit.xml.dist` | PHPUnit config |
+| `tests/bootstrap.php` | WP environment loader for PHPUnit |
+| `tests/Integration/SubscriptionFormTest.php` | PHPUnit integration tests |
+| `tests/Integration/SubscriberAudienceHashTest.php` | audienceHash PHPUnit tests |
+| `tests/js/subscription-form.test.js` | Jest frontend tests |
+| `package.json` | Jest deps |
+
+### Modified
+| File | Change |
+|---|---|
+| `classes/Tests.php` | Split `tests()` into named scenario methods, add `subscriptionFormScenario()` |
+| `templates/tests.php` | Replace auto-run with scenario button grid + `?run=` param dispatch |
+
+---
+
+## Test Implementation
+
+### Layer 1 — Tests.php refactor
+
+**`templates/tests.php` — new structure**
+
+Remove the direct `Tests::tests()` call. Replace with:
+1. Settings table (keep as-is)
+2. Scenario button grid — one button per scenario
+3. `?run=` param dispatch — renders results below the buttons
+
+```php
+$scenario = isset($_GET['run']) ? sanitize_key($_GET['run']) : null;
+$scenarios = [
+    'campaigns'          => 'Campaign CRUD',
+    'campaign-workflow'  => 'Campaign Workflow (test/approve/start/finish)',
+    'campaign-counters'  => 'Campaign Counters',
+    'campaign-template'  => 'Campaign Template & Placeholders',
+    'subscribers'        => 'Subscriber CRUD & Audience Hash',
+    'unsubscribe'        => 'Unsubscribe Flow',
+    'click-tracking'     => 'Click Tracking (triple-count)',
+    'subscription-form'  => 'Subscription Form',
+];
+// render buttons
+// if $scenario → call Tests::run($scenario)
+```
+
+**`Tests::run(string $scenario): void`** — dispatcher added to `Tests.php`:
+```php
+public static function run(string $scenario): void {
+    match($scenario) {
+        'campaigns'         => self::campaignScenario(),
+        'campaign-workflow' => self::campaignWorkflowScenario(),
+        'campaign-counters' => self::campaignCountersScenario(),
+        'campaign-template' => self::campaignTemplateScenario(),
+        'subscribers'       => self::subscriberScenario(),
+        'unsubscribe'       => self::unsubscribeScenario(),
+        'click-tracking'    => self::clickTrackingScenario(),
+        'subscription-form' => self::subscriptionFormScenario(),
+        default             => self::echoResult('Unknown scenario', 'error'),
+    };
+}
+```
+
+Each scenario method follows the same structure:
+```php
+public static function xyzScenario(): void {
+    self::echoHeading('XYZ');
+    // 1. setup  — create test data
+    // 2. assert — echoResult(pass/fail)
+    // 3. cleanup — delete test data
+}
+```
+
+---
+
+### Scenario specs
+
+#### `campaignScenario` (extract + clean up existing)
+- Setup: record campaign count before
+- Assert: `addCampaign` returns a post ID
+- Assert: `getCampaign($title)` finds it by title
+- Assert: `getCampaign($otherTitle)` returns null
+- Assert: `getCampaigns()` count increased by exactly 2
+- Assert: `getCampaignByHash($hash)` finds by hash
+- Assert: `isUnique($title)` returns false for existing, true for new
+- Cleanup: `deleteCampaign` × 2, count returns to baseline
+
+#### `campaignWorkflowScenario`
+- Setup: create one campaign
+- Assert: `testStarted` is false before `testStart()`
+- Assert: after `testStart()` — `testStarted` is a timestamp
+- Assert: after `testFinish()` — `testFinished` is a timestamp
+- Assert: after `testApprove()` — `testApproved` is a timestamp, `testMode` resolves to false
+- Assert: after `testReset()` — all three timestamps are false again
+- Assert: `campaignStart()` sets `campaignStarted`; calling it twice doesn't overwrite (guard check)
+- Assert: `campaignFinish()` sets `campaignFinished`
+- Cleanup: delete campaign
+
+#### `campaignCountersScenario`
+- Setup: create one campaign, zero counters
+- Assert: `getCounters()` returns object with all fields as 0
+- Assert: `updateCounters($c, 5, 1, 2, 1)` → `getCounters()` reflects new values
+- Assert: `incrementNewlyUnsubed()` → `emailsNewlyUnsubed` increases by 1
+- Assert: calling `updateCounters` again overwrites (not additive)
+- Cleanup: delete campaign
+
+#### `campaignTemplateScenario`
+- Setup: create campaign + subscriber with known hashes
+- Assert: `fillTemplate` replaces `{campaignHash}` with campaign's hash
+- Assert: `fillTemplate` replaces `{subscriberHash}` with subscriber's hash
+- Assert: `fillTemplate` replaces `{email}` with subscriber's email
+- Assert: URL-encoded variants `%7BcampaignHash%7D` also replaced
+- Assert: `lockTemplate` returns false when template doesn't exist
+- Cleanup: delete campaign + subscriber
+
+#### `subscriberScenario`
+- Setup: none (uses test email)
+- Assert: `addSubscriber('test@mawiblah.test')` returns subscriber object
+- Assert: `getSubscriber('test@mawiblah.test')` finds it
+- Assert: `getSubscriberById($id)` finds it
+- Assert: `getSubscriberBySubscriberHash($hash)` finds it
+- Assert: `appendMeta()` includes `audienceHash` on audience objects
+- Assert: calling `appendMeta()` twice returns same `audienceHash` (idempotent)
+- Assert: `addSubscriber` with same email does NOT create a duplicate
+- Assert: `getUnsubToken($id)` generates and persists token; second call returns same token
+- Assert: `isEmailSent($subId, $campaignId)` returns false before, true after `sentEmail()`
+- Assert: `isTester()` returns false by default; true after `addSubscriberToAudience(testerAudienceId)`
+- Cleanup: delete subscriber
+
+#### `unsubscribeScenario`
+- Setup: create subscriber, create campaign
+- Assert: `unsub($email, $wrongToken, '')` returns false, `unsubed` stays false
+- Assert: `unsub($email, $correctToken, 'feedback text')` returns true
+- Assert: subscriber `unsubed === true`, `unsub_time` is set
+- Assert: subscriber added to `unsubedAudience`
+- Assert: `unsubed_feedback` stored on subscriber
+- Assert: `incrementNewlyUnsubed($campaignId)` → counter increases
+- Assert: calling `unsub` again on already-unsubed subscriber — `Unsubscribe::unsubscribeAprooved` shows already-unsubed path
+- Cleanup: delete subscriber + campaign
+
+#### `clickTrackingScenario`
+- Setup: create campaign, create subscriber
+- Assert: before any visit — `linksClickedTotal`, `linksClicked`, `uniqueUserClicks` all 0
+- Assert: after `Visits::visit($campaignHash, $subscriberHash, $url)`:
+  - `linksClickedTotal` = 1
+  - `linksClicked` = 1
+  - `uniqueUserClicks` = 1
+- Assert: same subscriber, same URL again — `linksClickedTotal` = 2, others stay at 1
+- Assert: same subscriber, different URL — `linksClickedTotal` = 3, `linksClicked` = 2, `uniqueUserClicks` = 1
+- Assert: different subscriber, any URL — `uniqueUserClicks` = 2
+- Cleanup: delete campaign + subscribers
+
+#### `subscriptionFormScenario`
+- Setup: create 2 test audiences with known `audienceHash` values
+- Assert: new email → `SubscriptionForm::subscribe()` returns `ok`, subscriber exists, added to both audiences
+- Assert: same email again (active) → returns `ok` silently, still only 1 subscriber record
+- Assert: same email, one new audience → added to new audience, existing membership unchanged
+- Assert: honeypot filled → returns `ok` silently, no subscriber created
+- Assert: invalid email `'not-an-email'` → returns `error`, no subscriber created
+- Assert: mark subscriber as `unsubed`, resubmit → returns `ok` (check inbox), subscriber still unsubed (awaiting confirm)
+- Assert: re-subscribe with valid `resubToken` → `unsubed` cleared, added to audiences
+- Assert: re-subscribe with invalid token → rejected
+- Assert: multiple audiences in one call → subscriber added to all of them
+- Cleanup: delete test subscribers + audiences
+
+---
+
+### Layer 2 — PHPUnit class structure
+
+**`tests/Integration/SubscriptionFormTest.php`**
+```php
+class SubscriptionFormTest extends WP_UnitTestCase {
+    private array $testAudiences = [];
+    private array $testSubscribers = [];
+
+    public function setUp(): void { /* create shared fixtures */ }
+    public function tearDown(): void { /* delete all fixtures */ }
+
+    public function test_new_subscriber_is_created(): void {}
+    public function test_duplicate_submission_is_silent(): void {}
+    public function test_honeypot_rejects_silently(): void {}
+    public function test_invalid_email_returns_error(): void {}
+    public function test_unsubscribed_email_triggers_resubscribe_email(): void {}
+    public function test_valid_resub_token_clears_unsubed_flag(): void {}
+    public function test_invalid_resub_token_is_rejected(): void {}
+    public function test_subscriber_added_to_multiple_audiences(): void {}
+    public function test_partial_audience_overlap_adds_missing_only(): void {}
+}
+```
+
+**`tests/Integration/SubscriberTest.php`**
+```php
+class SubscriberTest extends WP_UnitTestCase {
+    public function test_audience_hash_is_generated_lazily(): void {}
+    public function test_audience_hash_is_idempotent(): void {}
+    public function test_add_subscriber_no_duplicate(): void {}
+    public function test_unsub_token_persists(): void {}
+    public function test_is_email_sent_flag(): void {}
+}
+```
+
+**`tests/Integration/CampaignTest.php`**
+```php
+class CampaignTest extends WP_UnitTestCase {
+    public function test_campaign_workflow_state_transitions(): void {}
+    public function test_counters_update_correctly(): void {}
+    public function test_fill_template_replaces_all_placeholders(): void {}
+    public function test_campaign_start_guard_against_double_start(): void {}
+}
+```
+
+**`tests/Integration/ClickTrackingTest.php`**
+```php
+class ClickTrackingTest extends WP_UnitTestCase {
+    public function test_total_increments_every_click(): void {}
+    public function test_unique_per_session_deduplicates_same_url(): void {}
+    public function test_unique_user_counted_once_per_subscriber(): void {}
+}
+```
+
+---
+
+### Layer 3 — Jest structure
+
+**`tests/js/subscription-form.test.js`**
+```js
+describe('subscription form', () => {
+    describe('submit payload', () => {
+        it('sends email and audienceHashes in POST body')
+        it('honeypot field is present in DOM but value is empty on normal submit')
+        it('attaches recaptcha token to payload when grecaptcha is available')
+        it('does not include recaptcha token when grecaptcha is absent')
+    })
+    describe('DOM state', () => {
+        it('adds loading class to wrapper while fetch is in flight')
+        it('disables submit button while loading')
+        it('shows success message and hides form on ok response')
+        it('shows error message and keeps form visible on error response')
+        it('removes loading class after fetch resolves')
+    })
+    describe('honeypot', () => {
+        it('honeypot input has display:none inline style')
+        it('honeypot input has tabindex=-1')
+    })
+})
+```
+
+---
+
+## Implementation Order
+
+1. `classes/Subscribers.php` — `audienceHash` in `appendAudienceMeta()`
+2. `config/sections.json` — reCAPTCHA settings section
+3. `classes/Settings.php` — three new getters
+4. `classes/SubscriptionForm.php` — REST endpoint + resubscribe handler
+5. `templates/subscription-form/` — form + confirmation templates
+6. `assets/css/subscription-form.css` — minimal styles
+7. `assets/js/subscription-form.js` — frontend JS
+8. `assets/js/block/subscription-form.js` — Gutenberg block
+9. `classes/ShortCodes.php` + `classes/Init.php` + `mawiblah.php` — wire up
+10. **Tests refactor** — split `Tests.php` into scenarios, button-triggered template
+11. **Layer 1** — `Tests::subscriptionFormScenario()` in-browser tests
+12. **Layer 2** — `composer.json`, PHPUnit setup, `SubscriptionFormTest.php`
+13. **Layer 3** — `package.json`, Jest setup, `subscription-form.test.js`
+14. Documentation — README, readme.txt, DOCUMENTATION.md

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -2,6 +2,10 @@
 
 ## Table of Contents
 - [Features Overview](#features-overview)
+- [User Flow Diagrams](#user-flow-diagrams)
+  - [Subscription Form](#subscription-form)
+  - [Campaign Lifecycle](#campaign-lifecycle)
+  - [Unsubscribe Flow](#unsubscribe-flow)
 - [Campaign Fields & Counters](#campaign-fields--counters)
 - [Click Tracking](#click-tracking)
 - [Email Templates](#email-templates)
@@ -11,6 +15,126 @@
 ## Features Overview
 
 MAWIBLAH is a WordPress email campaign plugin that provides basic email marketing functionality without recurring costs.
+
+## User Flow Diagrams
+
+### Subscription Form
+
+Shows how the shortcode / Gutenberg block renders a subscribe form and processes submissions. Includes honeypot spam protection, optional reCAPTCHA v3, multiple audience support, and re-subscribe confirmation for previously unsubscribed users.
+
+```mermaid
+flowchart TD
+    A[Editor adds block or shortcode\naudiencces='hash1,hash2'] --> B[Page renders HTML form\nemail input · hidden honeypot · submit]
+    B --> C{reCAPTCHA v3\nenabled in Settings?}
+    C -- Yes --> D[Load reCAPTCHA v3 script\nattach token on submit]
+    C -- No --> E[Plain form submit]
+    D & E --> F[JS POST /wp-json/mawiblah/v1/subscribe\nemail · audienceHashes · honeypot · recaptchaToken]
+
+    F --> G{Honeypot\nhas a value?}
+    G -- Yes --> H[Silently return success\nbot rejected]
+    G -- No --> I{reCAPTCHA\nenabled?}
+    I -- Yes --> J[Verify token via\nGoogle reCAPTCHA API]
+    J -- Score too low --> K[Return error:\nverification failed]
+    J -- Score OK --> L{Valid\nemail format?}
+    I -- No --> L
+    L -- No --> M[Return error:\ninvalid email]
+    L -- Yes --> N{Subscriber\nexists?}
+
+    N -- No --> O[Create subscriber\ngenerate subscriberHash]
+    O --> P[Add to all\ntarget audiences]
+    P --> Q[Return success\nnewly subscribed]
+
+    N -- Yes, unsubed --> R[Generate resubToken\nor reuse existing unsubToken]
+    R --> S[Send re-subscribe\nconfirmation email with link\naudiences encoded in URL]
+    S --> T[Return success\ncheck inbox to confirm]
+
+    N -- Yes, active --> U{Already in\nall target audiences?}
+    U -- Yes --> V[Return success\nsilently — no error]
+    U -- No --> W[Add to missing\naudiences only]
+    W --> X[Return success]
+
+    H & K & M & Q & T & V & X --> Y[JS swaps form\nfor success or error message]
+
+    T -.->|user clicks link| Z[GET confirmation URL\nresubToken · subscriberHash · audienceHashes]
+    Z --> AA{resubToken\nvalid?}
+    AA -- No --> AB[Show: invalid or\nexpired link page]
+    AA -- Yes --> AC[Clear unsubed flag\nrestore unsub_time=null\nadd to target audiences]
+    AC --> AD[Show: resubscribed\nsuccess page]
+```
+
+### Campaign Lifecycle
+
+From creation through test, approval, and final send to all subscribers.
+
+```mermaid
+flowchart TD
+    A[Admin creates campaign\ntitle · subject · template · audiences] --> B[Campaign saved as WP post]
+    B --> C[testStart\nsets testStarted timestamp]
+    C --> D[JS calls REST API per subscriber]
+    D --> E{testMode?\ntestStarted AND NOT testApproved}
+    E -- Yes --> F{Subscriber is a tester?}
+    F -- No --> G[Skip: not a tester]
+    F -- Yes --> H[Send test email via wp_mail]
+    G & H --> I{Last subscriber?}
+    I -- No --> D
+    I -- Yes --> J[testFinish\nsets testFinished timestamp]
+    J --> K{Admin reviews test emails}
+    K -- Redo --> L[testReset\nclears all test timestamps]
+    L --> C
+    K -- Approve --> M[testApprove\nsets testApproved timestamp]
+    M --> N[campaignStart\nsets campaignStarted\nstatus = sending-in-progress]
+    N --> O[JS calls REST API per subscriber\nfor all audiences]
+    O --> P{Unsubscribed?}
+    P -- Yes --> Q[Skip\nincrement emailsUnsubed]
+    P -- No --> R{Already sent?}
+    R -- Yes --> S[Skip: already sent]
+    R -- No --> T{Do-not-disturb\nthreshold active?}
+    T -- Yes --> U[Skip\nincrement emailsSkipped]
+    T -- No --> V{Email sending\nenabled in settings?}
+    V -- No --> W[Skip: emails disabled]
+    V -- Yes --> X[Lock template\nFill placeholders\ncampaignHash · subscriberHash · email]
+    X --> Y[wp_mail]
+    Y -- Success --> Z[Mark subscriber as sent\nincrement emailsSent\nupdateCounters]
+    Y -- Failed --> AA[Mark failed\nincrement emailsFailed\nupdateCounters]
+    Q & S & U & W & Z & AA --> AB{Last subscriber?}
+    AB -- No --> O
+    AB -- Yes --> AC[campaignFinish\nsets campaignFinished timestamp]
+```
+
+### Unsubscribe Flow
+
+Triggered when a subscriber clicks the unsubscribe link in a campaign email. The flow is a two-step confirmation: first shows a confirmation page, then processes the actual unsubscribe after the subscriber confirms.
+
+```mermaid
+flowchart TD
+    A[Subscriber clicks unsubscribe link\n?subscriber=hash&unsubscribe=email&campaign=hash] --> B{unsubToken\nin URL?}
+    B -- No --> C[unsubscribe called]
+    C --> D{Found in Subscribers\nor Gravity Forms?}
+    D -- No --> E[Show: not-found page]
+    D -- Yes --> F{Exists in\nSubscribers table?}
+    F -- No --> G[Add subscriber to DB]
+    F -- Yes --> H[Get unsubToken]
+    G --> H
+    H --> I[Show: are-you-sure\nconfirmation page]
+    I --> J[Subscriber submits confirmation\noptional feedback field]
+    J --> B
+    B -- Yes --> K[unsubscribeAprooved called]
+    K --> L{Subscriber found?}
+    L -- No --> M[Show: not-found page]
+    L -- Yes --> N{Already\nunsubscribed?}
+    N -- Yes --> O[Show: already-unsubed page]
+    N -- No --> P{unsubToken valid?}
+    P -- No --> Q[Show: not-found page]
+    P -- Yes --> R[Mark unsubed=true\nstore unsub_time]
+    R --> S[Add to Unsubbed audience]
+    S --> T{Feedback\nsubmitted?}
+    T -- Yes --> U[Store unsubed_feedback\non subscriber post]
+    T -- No --> V{campaignHash\npresent?}
+    U --> V
+    V -- Yes --> W[Increment emailsNewlyUnsubed\non campaign]
+    V -- No --> X[Show: unsubed success page]
+    W --> X
+```
 
 ## Campaign Fields & Counters
 
@@ -236,6 +360,80 @@ Shows which specific links in the campaign received the most clicks.
 ### Activity Timing
 - **Activity by Day:** Shows which days of the week generated the most engagement for this campaign.
 - **Activity by Hour:** Shows the time of day when subscribers were most active.
+
+## Subscription Form
+
+### Shortcode
+
+```
+[mawiblah_subscribe_form audiences="hash1,hash2"]
+```
+
+- `audiences` — comma-separated `audienceHash` values (plural, matches campaign field naming). Omit to subscribe without audience assignment.
+- Audience hashes are visible in the admin under **Mawiblah → Settings → reCAPTCHA** or via `Subscribers::getAllAudiences()`.
+
+### Gutenberg Block
+
+Block name: `mawiblah/subscription-form`. Add via the block inserter under **Widgets**. Select target audiences in the block settings panel (Inspector Controls). The block is server-side rendered — identical output to the shortcode.
+
+### HTML Structure & Class Reference
+
+```html
+<div class="mawiblah-subscribe-form">
+  <form class="mawiblah-subscribe-form__form">
+    <input type="text" name="website" style="display:none" tabindex="-1" autocomplete="off" />
+    <div class="mawiblah-subscribe-form__field">
+      <label class="mawiblah-subscribe-form__label" for="mawiblah-email">Email</label>
+      <input class="mawiblah-subscribe-form__input" type="email" id="mawiblah-email" />
+    </div>
+    <div class="mawiblah-subscribe-form__actions">
+      <button class="mawiblah-subscribe-form__button" type="submit">Subscribe</button>
+    </div>
+  </form>
+  <div class="mawiblah-subscribe-form__message mawiblah-subscribe-form__message--success" hidden></div>
+  <div class="mawiblah-subscribe-form__message mawiblah-subscribe-form__message--error"   hidden></div>
+</div>
+```
+
+**JS state modifiers on wrapper:**
+- `mawiblah-subscribe-form--loading` — while fetch is in flight
+- `mawiblah-subscribe-form--submitted` — after success (theme can hide the form with `.mawiblah-subscribe-form--submitted .mawiblah-subscribe-form__form { display: none }`)
+
+### Settings — reCAPTCHA v3
+
+| Option key | Type | Purpose |
+|---|---|---|
+| `mawiblah-recaptcha-enabled` | select (`enabled`/`disabled`) | Toggle reCAPTCHA v3 |
+| `mawiblah-recaptcha-site-key` | text | Google site key (public) |
+| `mawiblah-recaptcha-secret-key` | text | Google secret key (private) |
+
+PHP getters: `Settings::recaptchaEnabled()`, `Settings::recaptchaSiteKey()`, `Settings::recaptchaSecretKey()`
+
+### REST Endpoint
+
+`POST /wp-json/mawiblah/v1/subscribe` — public, no authentication required.
+
+**Request body:**
+```json
+{
+  "email": "user@example.com",
+  "audienceHashes": ["hash1", "hash2"],
+  "honeypot": "",
+  "recaptchaToken": "..."
+}
+```
+
+**Responses:**
+```json
+{ "status": "ok",    "message": "You are now subscribed!" }
+{ "status": "ok",    "message": "Check your inbox to confirm your subscription." }
+{ "status": "error", "message": "Invalid email address." }
+{ "status": "error", "message": "Verification failed. Please try again." }
+```
+
+### Audience Hash
+
+Each audience (taxonomy term) has a stable `audienceHash` — an MD5 of its `term_id`, stored as term meta. Generated lazily on first access via `Subscribers::appendAudienceMeta()`. Use `Subscribers::getAudienceByHash(string $hash)` to resolve a hash back to an audience object.
 
 ## API Functions
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ So... "Fine... will do my own Mailchimp... with blackjack and hookers"
 ## What it does
 - Sends out emails to the email list.
 - The email list is collected via Gravity Forms entries, but one can add the mailing list manually.
+- **Native subscription form** — embed a sign-up form anywhere via `[mawiblah_subscribe_form]` shortcode or Gutenberg block, with honeypot + optional reCAPTCHA v3 spam protection.
 - The email template that is sent out is generated via shortcodes.
 - Includes unsubscribe functionality.
 - Imports a list of unsubscribed users from Mailchimp.
@@ -47,7 +48,7 @@ on all possible configurations and setups.
 | **Subscriber Limit**            | Unlimited (practical limits apply)               | 500 (Free), 2,500 (Essentials base)         | Scales with plan                       |
 | **Email Sending**               | One-by-one (slower, lower server load)           | Batch sending via Mailchimp servers         | Batch sending, faster delivery         |
 | **SMTP / Delivery Backend**     | Uses WordPress mail system (SMTP or `wp_mail`)   | Mailchimp’s dedicated infrastructure        | Same                                   |
-| **Form Integration**            | Gravity Forms                                    | Native signup forms                         | Advanced forms, popups                 |
+| **Form Integration**            | Gravity Forms + native subscription form (shortcode & Gutenberg block) | Native signup forms      | Advanced forms, popups                 |
 | **Email Templates**             | Shortcode-based + HTML                           | Drag-and-drop editor                        | Advanced email builder                 |
 | **Automation**                  | ❌ Not available at current version              | ✅ Basic (welcome emails)                   | ✅ Multi-step automation               |
 | **Click Tracking**              | ✅ Basic (clicks & timing logged)                | ✅ Basic reports                             | ✅ Advanced click stats                |
@@ -64,6 +65,18 @@ on all possible configurations and setups.
 
 
 ## Change log
+
+### --- 1.0.17 ---
+- **New:** Native subscription form — add a sign-up form anywhere via `[mawiblah_subscribe_form audiences="hash1,hash2"]` shortcode or Gutenberg block.
+- **New:** Multiple audience support — assign subscribers to one or more audiences from a single form.
+- **New:** `audienceHash` — stable MD5 hash per audience term, consistent with `subscriberHash` / `campaignHash` pattern.
+- **New:** Honeypot spam protection (always active, zero UX impact).
+- **New:** Optional reCAPTCHA v3 support — configure site key and secret key in Settings.
+- **New:** Re-subscribe confirmation flow — previously unsubscribed users receive a confirmation email before being re-added.
+- **New:** reCAPTCHA v3 settings section added to the Settings page.
+- **New:** PHPUnit integration test suite (`composer test`) covering subscription form, subscribers, campaigns, and click tracking.
+- **New:** Jest frontend test suite (`npm test`) covering form payload, DOM state, and honeypot behaviour.
+- **Improved:** Test page refactored — scenarios are now button-triggered (not auto-run on page load) and split into named, self-contained scenarios.
 
 ### --- 1.0.16 ---
 - **Code Quality & Naming Consistency:** Major refactoring for better maintainability and clarity:

--- a/assets/css/subscription-form.css
+++ b/assets/css/subscription-form.css
@@ -1,0 +1,50 @@
+.mawiblah-subscribe-form {
+    display: block;
+    width: 100%;
+}
+
+.mawiblah-subscribe-form__form {
+    display: block;
+}
+
+.mawiblah-subscribe-form__field {
+    display: block;
+    margin-bottom: 0.75em;
+}
+
+.mawiblah-subscribe-form__label {
+    display: block;
+    margin-bottom: 0.25em;
+}
+
+.mawiblah-subscribe-form__input {
+    display: block;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+.mawiblah-subscribe-form__actions {
+    display: block;
+    margin-top: 0.75em;
+}
+
+.mawiblah-subscribe-form__message {
+    display: block;
+    margin-top: 0.75em;
+}
+
+.mawiblah-subscribe-form__message[hidden] {
+    display: none;
+}
+
+/* Loading state */
+.mawiblah-subscribe-form--loading .mawiblah-subscribe-form__button {
+    opacity: 0.6;
+    pointer-events: none;
+    cursor: default;
+}
+
+/* Submitted state — theme can use this to hide the form */
+.mawiblah-subscribe-form--submitted .mawiblah-subscribe-form__form {
+    display: none;
+}

--- a/assets/css/subscription-form.css
+++ b/assets/css/subscription-form.css
@@ -44,7 +44,67 @@
     cursor: default;
 }
 
-/* Submitted state — theme can use this to hide the form */
+/* Submitted state — hide the form */
 .mawiblah-subscribe-form--submitted .mawiblah-subscribe-form__form {
     display: none;
+}
+
+/* Shared alert box style */
+.mawiblah-subscribe-form__message--success,
+.mawiblah-subscribe-form__message--error {
+    display: flex;
+    align-items: center;
+    gap: 0.75em;
+    padding: 0.875em 1.125em;
+    border-radius: 4px;
+    font-size: 0.95rem;
+    line-height: 1.4;
+    margin-top: 0.75em;
+}
+
+.mawiblah-subscribe-form__message--success[hidden],
+.mawiblah-subscribe-form__message--error[hidden] {
+    display: none;
+}
+
+/* Success */
+.mawiblah-subscribe-form__message--success {
+    background: #f0faf4;
+    border: 1px solid #6fcf97;
+    border-left: 4px solid #27ae60;
+    color: #1a5c35;
+}
+
+.mawiblah-subscribe-form__message--success::before {
+    content: '';
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    background-color: #27ae60;
+    border-radius: 50%;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'%3E%3Cpath d='M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z'/%3E%3C/svg%3E");
+    background-size: 14px 14px;
+    background-repeat: no-repeat;
+    background-position: center;
+}
+
+/* Error */
+.mawiblah-subscribe-form__message--error {
+    background: #fdf3f3;
+    border: 1px solid #f1a9a9;
+    border-left: 4px solid #e74c3c;
+    color: #7b1a1a;
+}
+
+.mawiblah-subscribe-form__message--error::before {
+    content: '';
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    background-color: #e74c3c;
+    border-radius: 50%;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'%3E%3Cpath d='M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z'/%3E%3C/svg%3E");
+    background-size: 14px 14px;
+    background-repeat: no-repeat;
+    background-position: center;
 }

--- a/assets/js/block/subscription-form.js
+++ b/assets/js/block/subscription-form.js
@@ -1,12 +1,13 @@
 (function (blocks, element, blockEditor, components, i18n) {
     'use strict';
 
-    var el               = element.createElement;
-    var useBlockProps    = blockEditor.useBlockProps;
+    var el                = element.createElement;
+    var useBlockProps     = blockEditor.useBlockProps;
     var InspectorControls = blockEditor.InspectorControls;
-    var PanelBody        = components.PanelBody;
-    var CheckboxControl  = components.CheckboxControl;
-    var __               = i18n.__;
+    var PanelBody         = components.PanelBody;
+    var CheckboxControl   = components.CheckboxControl;
+    var TextControl       = components.TextControl;
+    var __                = i18n.__;
 
     var audiences = mawiblahSubscriptionBlock.audiences || [];
 
@@ -15,14 +16,15 @@
         icon: 'email-alt2',
         category: 'mawiblah',
         attributes: {
-            audienceHashes: {
-                type: 'array',
-                default: [],
-            },
+            audienceHashes: { type: 'array',  default: [] },
+            label:          { type: 'string', default: '' },
+            placeholder:    { type: 'string', default: '' },
+            buttonText:     { type: 'string', default: '' },
         },
 
         edit: function (props) {
-            var audienceHashes = props.attributes.audienceHashes;
+            var attrs          = props.attributes;
+            var audienceHashes = attrs.audienceHashes;
 
             function toggleAudience(hash, checked) {
                 var next = checked
@@ -39,6 +41,28 @@
                 el(
                     InspectorControls,
                     null,
+                    el(
+                        PanelBody,
+                        { title: __('Form Text', 'mawiblah'), initialOpen: true },
+                        el(TextControl, {
+                            label:       __('Field label', 'mawiblah'),
+                            placeholder: __('Email', 'mawiblah'),
+                            value:       attrs.label,
+                            onChange:    function (val) { props.setAttributes({ label: val }); },
+                        }),
+                        el(TextControl, {
+                            label:       __('Input placeholder', 'mawiblah'),
+                            placeholder: __('your@email.com', 'mawiblah'),
+                            value:       attrs.placeholder,
+                            onChange:    function (val) { props.setAttributes({ placeholder: val }); },
+                        }),
+                        el(TextControl, {
+                            label:       __('Button text', 'mawiblah'),
+                            placeholder: __('Subscribe', 'mawiblah'),
+                            value:       attrs.buttonText,
+                            onChange:    function (val) { props.setAttributes({ buttonText: val }); },
+                        })
+                    ),
                     el(
                         PanelBody,
                         { title: __('Audiences', 'mawiblah'), initialOpen: true },

--- a/assets/js/block/subscription-form.js
+++ b/assets/js/block/subscription-form.js
@@ -1,0 +1,80 @@
+(function (blocks, element, blockEditor, components) {
+    'use strict';
+
+    var el          = element.createElement;
+    var useBlockProps = blockEditor.useBlockProps;
+    var InspectorControls = blockEditor.InspectorControls;
+    var PanelBody   = components.PanelBody;
+    var CheckboxControl = components.CheckboxControl;
+
+    var audiences = mawiblahSubscriptionBlock.audiences || [];
+
+    blocks.registerBlockType('mawiblah/subscription-form', {
+        title: 'Mawiblah Subscription Form',
+        icon: 'email-alt2',
+        category: 'widgets',
+        attributes: {
+            audienceHashes: {
+                type: 'array',
+                default: [],
+            },
+        },
+
+        edit: function (props) {
+            var audienceHashes = props.attributes.audienceHashes;
+
+            function toggleAudience(hash, checked) {
+                var next = checked
+                    ? audienceHashes.concat([hash])
+                    : audienceHashes.filter(function (h) { return h !== hash; });
+                props.setAttributes({ audienceHashes: next });
+            }
+
+            var blockProps = useBlockProps();
+
+            return el(
+                'div',
+                blockProps,
+                el(
+                    InspectorControls,
+                    null,
+                    el(
+                        PanelBody,
+                        { title: 'Audiences', initialOpen: true },
+                        audiences.length === 0
+                            ? el('p', null, 'No audiences found. Create one first.')
+                            : audiences.map(function (audience) {
+                                return el(CheckboxControl, {
+                                    key: audience.hash,
+                                    label: audience.name,
+                                    checked: audienceHashes.indexOf(audience.hash) !== -1,
+                                    onChange: function (checked) {
+                                        toggleAudience(audience.hash, checked);
+                                    },
+                                });
+                            })
+                    )
+                ),
+                el(
+                    'div',
+                    { className: 'mawiblah-subscribe-form-preview' },
+                    el('p', null, 'Mawiblah Subscription Form'),
+                    audienceHashes.length > 0
+                        ? el('small', null, 'Audiences: ' + audienceHashes.join(', '))
+                        : el('small', null, 'No audiences selected')
+                )
+            );
+        },
+
+        save: function () {
+            // Server-side rendered — return null
+            return null;
+        },
+    });
+
+}(
+    window.wp.blocks,
+    window.wp.element,
+    window.wp.blockEditor,
+    window.wp.components
+));

--- a/assets/js/block/subscription-form.js
+++ b/assets/js/block/subscription-form.js
@@ -11,9 +11,9 @@
     var audiences = mawiblahSubscriptionBlock.audiences || [];
 
     blocks.registerBlockType('mawiblah/subscription-form', {
-        title: __('Mawiblah Subscription Form', 'mawiblah'),
+        title: __('Mawiblah Subscribe', 'mawiblah'),
         icon: 'email-alt2',
-        category: 'widgets',
+        category: 'mawiblah',
         attributes: {
             audienceHashes: {
                 type: 'array',
@@ -59,7 +59,7 @@
                 el(
                     'div',
                     { className: 'mawiblah-subscribe-form-preview' },
-                    el('p', null, __('Mawiblah Subscription Form', 'mawiblah')),
+                    el('p', null, __('Mawiblah Subscribe', 'mawiblah')),
                     audienceHashes.length > 0
                         ? el('small', null, __('Audiences: ', 'mawiblah') + audienceHashes.join(', '))
                         : el('small', null, __('No audiences selected', 'mawiblah'))

--- a/assets/js/block/subscription-form.js
+++ b/assets/js/block/subscription-form.js
@@ -1,16 +1,17 @@
-(function (blocks, element, blockEditor, components) {
+(function (blocks, element, blockEditor, components, i18n) {
     'use strict';
 
-    var el          = element.createElement;
-    var useBlockProps = blockEditor.useBlockProps;
+    var el               = element.createElement;
+    var useBlockProps    = blockEditor.useBlockProps;
     var InspectorControls = blockEditor.InspectorControls;
-    var PanelBody   = components.PanelBody;
-    var CheckboxControl = components.CheckboxControl;
+    var PanelBody        = components.PanelBody;
+    var CheckboxControl  = components.CheckboxControl;
+    var __               = i18n.__;
 
     var audiences = mawiblahSubscriptionBlock.audiences || [];
 
     blocks.registerBlockType('mawiblah/subscription-form', {
-        title: 'Mawiblah Subscription Form',
+        title: __('Mawiblah Subscription Form', 'mawiblah'),
         icon: 'email-alt2',
         category: 'widgets',
         attributes: {
@@ -40,9 +41,9 @@
                     null,
                     el(
                         PanelBody,
-                        { title: 'Audiences', initialOpen: true },
+                        { title: __('Audiences', 'mawiblah'), initialOpen: true },
                         audiences.length === 0
-                            ? el('p', null, 'No audiences found. Create one first.')
+                            ? el('p', null, __('No audiences found. Create one first.', 'mawiblah'))
                             : audiences.map(function (audience) {
                                 return el(CheckboxControl, {
                                     key: audience.hash,
@@ -58,10 +59,10 @@
                 el(
                     'div',
                     { className: 'mawiblah-subscribe-form-preview' },
-                    el('p', null, 'Mawiblah Subscription Form'),
+                    el('p', null, __('Mawiblah Subscription Form', 'mawiblah')),
                     audienceHashes.length > 0
-                        ? el('small', null, 'Audiences: ' + audienceHashes.join(', '))
-                        : el('small', null, 'No audiences selected')
+                        ? el('small', null, __('Audiences: ', 'mawiblah') + audienceHashes.join(', '))
+                        : el('small', null, __('No audiences selected', 'mawiblah'))
                 )
             );
         },
@@ -76,5 +77,6 @@
     window.wp.blocks,
     window.wp.element,
     window.wp.blockEditor,
-    window.wp.components
+    window.wp.components,
+    window.wp.i18n
 ));

--- a/assets/js/block/subscription-form.js
+++ b/assets/js/block/subscription-form.js
@@ -20,6 +20,8 @@
             label:          { type: 'string', default: '' },
             placeholder:    { type: 'string', default: '' },
             buttonText:     { type: 'string', default: '' },
+            successMessage: { type: 'string', default: '' },
+            errorMessage:   { type: 'string', default: '' },
         },
 
         edit: function (props) {
@@ -61,6 +63,18 @@
                             placeholder: __('Subscribe', 'mawiblah'),
                             value:       attrs.buttonText,
                             onChange:    function (val) { props.setAttributes({ buttonText: val }); },
+                        }),
+                        el(TextControl, {
+                            label:       __('Success message', 'mawiblah'),
+                            placeholder: __('You are now subscribed!', 'mawiblah'),
+                            value:       attrs.successMessage,
+                            onChange:    function (val) { props.setAttributes({ successMessage: val }); },
+                        }),
+                        el(TextControl, {
+                            label:       __('Error message', 'mawiblah'),
+                            placeholder: __('Something went wrong. Please try again.', 'mawiblah'),
+                            value:       attrs.errorMessage,
+                            onChange:    function (val) { props.setAttributes({ errorMessage: val }); },
                         })
                     ),
                     el(

--- a/assets/js/subscription-form.js
+++ b/assets/js/subscription-form.js
@@ -51,14 +51,14 @@
                 clearLoading();
                 if (data.status === 'ok') {
                     wrapper.classList.add('mawiblah-subscribe-form--submitted');
-                    showMessage(wrapper, 'success', data.message);
+                    showMessage(wrapper, 'success', wrapper.dataset.successMessage || data.message);
                 } else {
-                    showMessage(wrapper, 'error', data.message);
+                    showMessage(wrapper, 'error', wrapper.dataset.errorMessage || data.message);
                 }
             })
             .catch(function () {
                 clearLoading();
-                showMessage(wrapper, 'error', mawiblahSubscribeFormData.errorMessage);
+                showMessage(wrapper, 'error', wrapper.dataset.errorMessage || mawiblahSubscribeFormData.errorMessage);
             });
         }
 
@@ -68,7 +68,7 @@
                     doSubmit(token);
                 }).catch(function () {
                     clearLoading();
-                    showMessage(wrapper, 'error', mawiblahSubscribeFormData.errorMessage);
+                    showMessage(wrapper, 'error', wrapper.dataset.errorMessage || mawiblahSubscribeFormData.errorMessage);
                 });
             });
         } else {

--- a/assets/js/subscription-form.js
+++ b/assets/js/subscription-form.js
@@ -20,12 +20,20 @@
     function handleSubmit(wrapper, form, event) {
         event.preventDefault();
 
+        if (wrapper.classList.contains('mawiblah-subscribe-form--loading')) {
+            return;
+        }
+
         var email     = form.querySelector('.mawiblah-subscribe-form__input').value;
         var honeypot  = form.querySelector('input[name="website"]').value;
         var audiences = getAudienceHashes(form);
         var siteKey   = wrapper.dataset.recaptchaSiteKey || '';
 
         wrapper.classList.add('mawiblah-subscribe-form--loading');
+
+        function clearLoading() {
+            wrapper.classList.remove('mawiblah-subscribe-form--loading');
+        }
 
         function doSubmit(recaptchaToken) {
             fetch(mawiblahSubscribeFormData.restUrl, {
@@ -40,7 +48,7 @@
             })
             .then(function (res) { return res.json(); })
             .then(function (data) {
-                wrapper.classList.remove('mawiblah-subscribe-form--loading');
+                clearLoading();
                 if (data.status === 'ok') {
                     wrapper.classList.add('mawiblah-subscribe-form--submitted');
                     showMessage(wrapper, 'success', data.message);
@@ -49,7 +57,7 @@
                 }
             })
             .catch(function () {
-                wrapper.classList.remove('mawiblah-subscribe-form--loading');
+                clearLoading();
                 showMessage(wrapper, 'error', mawiblahSubscribeFormData.errorMessage);
             });
         }
@@ -58,6 +66,9 @@
             grecaptcha.ready(function () {
                 grecaptcha.execute(siteKey, { action: 'subscribe' }).then(function (token) {
                     doSubmit(token);
+                }).catch(function () {
+                    clearLoading();
+                    showMessage(wrapper, 'error', mawiblahSubscribeFormData.errorMessage);
                 });
             });
         } else {

--- a/assets/js/subscription-form.js
+++ b/assets/js/subscription-form.js
@@ -1,0 +1,77 @@
+(function () {
+    'use strict';
+
+    function getAudienceHashes(form) {
+        return Array.from(form.querySelectorAll('.mawiblah-subscribe-form__audience'))
+            .map(function (el) { return el.value; });
+    }
+
+    function showMessage(wrapper, type, text) {
+        var success = wrapper.querySelector('.mawiblah-subscribe-form__message--success');
+        var error   = wrapper.querySelector('.mawiblah-subscribe-form__message--error');
+        success.hidden = true;
+        error.hidden   = true;
+
+        var target = type === 'success' ? success : error;
+        target.textContent = text;
+        target.hidden = false;
+    }
+
+    function handleSubmit(wrapper, form, event) {
+        event.preventDefault();
+
+        var email     = form.querySelector('.mawiblah-subscribe-form__input').value;
+        var honeypot  = form.querySelector('input[name="website"]').value;
+        var audiences = getAudienceHashes(form);
+        var siteKey   = wrapper.dataset.recaptchaSiteKey || '';
+
+        wrapper.classList.add('mawiblah-subscribe-form--loading');
+
+        function doSubmit(recaptchaToken) {
+            fetch(mawiblahSubscribeFormData.restUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    email:          email,
+                    audienceHashes: audiences,
+                    honeypot:       honeypot,
+                    recaptchaToken: recaptchaToken || '',
+                }),
+            })
+            .then(function (res) { return res.json(); })
+            .then(function (data) {
+                wrapper.classList.remove('mawiblah-subscribe-form--loading');
+                if (data.status === 'ok') {
+                    wrapper.classList.add('mawiblah-subscribe-form--submitted');
+                    showMessage(wrapper, 'success', data.message);
+                } else {
+                    showMessage(wrapper, 'error', data.message);
+                }
+            })
+            .catch(function () {
+                wrapper.classList.remove('mawiblah-subscribe-form--loading');
+                showMessage(wrapper, 'error', mawiblahSubscribeFormData.errorMessage);
+            });
+        }
+
+        if (siteKey && typeof grecaptcha !== 'undefined') {
+            grecaptcha.ready(function () {
+                grecaptcha.execute(siteKey, { action: 'subscribe' }).then(function (token) {
+                    doSubmit(token);
+                });
+            });
+        } else {
+            doSubmit('');
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        document.querySelectorAll('.mawiblah-subscribe-form').forEach(function (wrapper) {
+            var form = wrapper.querySelector('.mawiblah-subscribe-form__form');
+            if (!form) return;
+            form.addEventListener('submit', function (e) {
+                handleSubmit(wrapper, form, e);
+            });
+        });
+    });
+}());

--- a/classes/Campaigns.php
+++ b/classes/Campaigns.php
@@ -804,8 +804,8 @@ class Campaigns
         $campaign = self::getCampaignById($campaignPostId);
         if ($campaign && !$campaign->campaignStarted) {
             self::resetCounters($campaignPostId);
+            update_post_meta($campaignPostId, 'campaignStarted', time());
         }
-        update_post_meta($campaignPostId, 'campaignStarted', time());
     }
 
     public static function campaignFinish(int $campaignPostId): void

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -137,7 +137,7 @@ class Init
         wp_register_script(
             'mawiblah-subscription-form-block-js',
             MAWIBLAH_PLUGIN_URL . '/assets/js/block/subscription-form.js',
-            ['wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components'],
+            ['wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n'],
             MAWIBLAH_VERSION
         );
         wp_localize_script('mawiblah-subscription-form-block-js', 'mawiblahSubscriptionBlock', [

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -133,13 +133,17 @@ class Init
                 'label'          => ['type' => 'string', 'default' => ''],
                 'placeholder'    => ['type' => 'string', 'default' => ''],
                 'buttonText'     => ['type' => 'string', 'default' => ''],
+                'successMessage' => ['type' => 'string', 'default' => ''],
+                'errorMessage'   => ['type' => 'string', 'default' => ''],
             ],
             'render_callback' => function (array $attrs): string {
                 $hashes  = array_map('sanitize_text_field', $attrs['audienceHashes'] ?? []);
                 $options = array_filter([
-                    'label'       => sanitize_text_field($attrs['label'] ?? ''),
-                    'placeholder' => sanitize_text_field($attrs['placeholder'] ?? ''),
-                    'buttonText'  => sanitize_text_field($attrs['buttonText'] ?? ''),
+                    'label'          => sanitize_text_field($attrs['label'] ?? ''),
+                    'placeholder'    => sanitize_text_field($attrs['placeholder'] ?? ''),
+                    'buttonText'     => sanitize_text_field($attrs['buttonText'] ?? ''),
+                    'successMessage' => sanitize_text_field($attrs['successMessage'] ?? ''),
+                    'errorMessage'   => sanitize_text_field($attrs['errorMessage'] ?? ''),
                 ]);
 
                 wp_enqueue_style('mawiblah-subscription-form-css', MAWIBLAH_PLUGIN_URL . '/assets/css/subscription-form.css', [], MAWIBLAH_VERSION);

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -14,6 +14,7 @@ class Init
     const MAWIBLAH_SETTINGS = 'mawiblah-settings';
 
     const MAWIBLAH_ACTIONS = 'mawiblah-actions';
+    const MAWIBLAH_HELP    = 'mawiblah-help';
     public function init(): void
     {
         Migrations::run();
@@ -33,7 +34,8 @@ class Init
             self::MAWIBLAH_EMAIL_TEMPLATES,
             self::MAWIBLAH_TESTS,
             self::MAWIBLAH_SETTINGS,
-            self::MAWIBLAH_ACTIONS
+            self::MAWIBLAH_ACTIONS,
+            self::MAWIBLAH_HELP,
         ];
     }
 
@@ -257,6 +259,15 @@ class Init
             self::MAWIBLAH_SETTINGS,
             [$this, 'settings']
         );
+
+        add_submenu_page(
+            'mawiblah',
+            'Help',
+            'Help',
+            'manage_options',
+            self::MAWIBLAH_HELP,
+            [$this, 'help']
+        );
     }
 
     public function emailTemplates() {
@@ -282,5 +293,9 @@ class Init
 
     public function actions() {
         Renderer::actions();
+    }
+
+    public function help() {
+        Renderer::help();
     }
 }

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -112,20 +112,28 @@ class Init
 
     public function registerBlocks(): void
     {
-        // Script must be registered before register_block_type references it
-        $audiences = array_map(function ($a) {
-            return ['hash' => $a->audienceHash, 'name' => $a->name];
-        }, Subscribers::getAllAudiences());
-
+        // Register the script early (before register_block_type references it)
         wp_register_script(
             'mawiblah-subscription-form-block-js',
             MAWIBLAH_PLUGIN_URL . '/assets/js/block/subscription-form.js',
             ['wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n'],
             MAWIBLAH_VERSION
         );
-        wp_localize_script('mawiblah-subscription-form-block-js', 'mawiblahSubscriptionBlock', [
-            'audiences' => $audiences,
-        ]);
+
+        // Localize audiences on enqueue_block_editor_assets so the taxonomy
+        // is already registered by Subscribers::init() when we query it.
+        add_action('enqueue_block_editor_assets', function () {
+            $systemAudiences = ['Unsubed', 'Testers'];
+            $audiences = array_values(array_map(function ($a) {
+                return ['hash' => $a->audienceHash, 'name' => $a->name];
+            }, array_filter(Subscribers::getAllAudiences(), function ($a) use ($systemAudiences) {
+                return !in_array($a->name, $systemAudiences, true);
+            })));
+
+            wp_localize_script('mawiblah-subscription-form-block-js', 'mawiblahSubscriptionBlock', [
+                'audiences' => $audiences,
+            ]);
+        });
 
         register_block_type('mawiblah/subscription-form', [
             'attributes'      => [

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -22,7 +22,8 @@ class Init
         }
         $this->setup_hooks();
         $this->setup_api_routes();
-        add_action('init', [$this, 'registerBlocks']);
+        $this->registerBlocks();
+        add_filter('block_categories_all', [$this, 'registerBlockCategories'], 10, 2);
     }
 
     public static function getIdsOfPages(){
@@ -111,6 +112,21 @@ class Init
 
     public function registerBlocks(): void
     {
+        // Script must be registered before register_block_type references it
+        $audiences = array_map(function ($a) {
+            return ['hash' => $a->audienceHash, 'name' => $a->name];
+        }, Subscribers::getAllAudiences());
+
+        wp_register_script(
+            'mawiblah-subscription-form-block-js',
+            MAWIBLAH_PLUGIN_URL . '/assets/js/block/subscription-form.js',
+            ['wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n'],
+            MAWIBLAH_VERSION
+        );
+        wp_localize_script('mawiblah-subscription-form-block-js', 'mawiblahSubscriptionBlock', [
+            'audiences' => $audiences,
+        ]);
+
         register_block_type('mawiblah/subscription-form', [
             'attributes'      => [
                 'audienceHashes' => ['type' => 'array', 'default' => []],
@@ -129,20 +145,16 @@ class Init
             },
             'editor_script'   => 'mawiblah-subscription-form-block-js',
         ]);
+    }
 
-        $audiences = array_map(function ($a) {
-            return ['hash' => $a->audienceHash, 'name' => $a->name];
-        }, Subscribers::getAllAudiences());
-
-        wp_register_script(
-            'mawiblah-subscription-form-block-js',
-            MAWIBLAH_PLUGIN_URL . '/assets/js/block/subscription-form.js',
-            ['wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components', 'wp-i18n'],
-            MAWIBLAH_VERSION
-        );
-        wp_localize_script('mawiblah-subscription-form-block-js', 'mawiblahSubscriptionBlock', [
-            'audiences' => $audiences,
+    public function registerBlockCategories(array $categories): array
+    {
+        array_unshift($categories, [
+            'slug'  => 'mawiblah',
+            'title' => 'Mawiblah',
+            'icon'  => 'email-alt2',
         ]);
+        return $categories;
     }
 
     public function my_custom_rest_api_nonce()

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -129,10 +129,18 @@ class Init
 
         register_block_type('mawiblah/subscription-form', [
             'attributes'      => [
-                'audienceHashes' => ['type' => 'array', 'default' => []],
+                'audienceHashes' => ['type' => 'array',  'default' => []],
+                'label'          => ['type' => 'string', 'default' => ''],
+                'placeholder'    => ['type' => 'string', 'default' => ''],
+                'buttonText'     => ['type' => 'string', 'default' => ''],
             ],
             'render_callback' => function (array $attrs): string {
-                $hashes = array_map('sanitize_text_field', $attrs['audienceHashes'] ?? []);
+                $hashes  = array_map('sanitize_text_field', $attrs['audienceHashes'] ?? []);
+                $options = array_filter([
+                    'label'       => sanitize_text_field($attrs['label'] ?? ''),
+                    'placeholder' => sanitize_text_field($attrs['placeholder'] ?? ''),
+                    'buttonText'  => sanitize_text_field($attrs['buttonText'] ?? ''),
+                ]);
 
                 wp_enqueue_style('mawiblah-subscription-form-css', MAWIBLAH_PLUGIN_URL . '/assets/css/subscription-form.css', [], MAWIBLAH_VERSION);
                 wp_enqueue_script('mawiblah-subscription-form-js', MAWIBLAH_PLUGIN_URL . '/assets/js/subscription-form.js', [], MAWIBLAH_VERSION, true);
@@ -141,7 +149,7 @@ class Init
                     'errorMessage' => __('Something went wrong. Please try again.', 'mawiblah'),
                 ]);
 
-                return SubscriptionForm::renderForm($hashes);
+                return SubscriptionForm::renderForm($hashes, $options);
             },
             'editor_script'   => 'mawiblah-subscription-form-block-js',
         ]);

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -22,7 +22,7 @@ class Init
         }
         $this->setup_hooks();
         $this->setup_api_routes();
-
+        add_action('init', [$this, 'registerBlocks']);
     }
 
     public static function getIdsOfPages(){
@@ -76,6 +76,12 @@ class Init
                 }
             ));
 
+            register_rest_route('mawiblah/v1', '/subscribe', array(
+                'methods'             => 'POST',
+                'callback'            => 'Mawiblah\SubscriptionForm::subscribe',
+                'permission_callback' => '__return_true',
+            ));
+
         });
     }
 
@@ -101,6 +107,42 @@ class Init
     public function registerPostsTypesAndTaxamonies()
     {
         Subscribers::registerPostType();
+    }
+
+    public function registerBlocks(): void
+    {
+        register_block_type('mawiblah/subscription-form', [
+            'attributes'      => [
+                'audienceHashes' => ['type' => 'array', 'default' => []],
+            ],
+            'render_callback' => function (array $attrs): string {
+                $hashes = array_map('sanitize_text_field', $attrs['audienceHashes'] ?? []);
+
+                wp_enqueue_style('mawiblah-subscription-form-css', MAWIBLAH_PLUGIN_URL . '/assets/css/subscription-form.css', [], MAWIBLAH_VERSION);
+                wp_enqueue_script('mawiblah-subscription-form-js', MAWIBLAH_PLUGIN_URL . '/assets/js/subscription-form.js', [], MAWIBLAH_VERSION, true);
+                wp_localize_script('mawiblah-subscription-form-js', 'mawiblahSubscribeFormData', [
+                    'restUrl'      => rest_url('mawiblah/v1/subscribe'),
+                    'errorMessage' => __('Something went wrong. Please try again.', 'mawiblah'),
+                ]);
+
+                return SubscriptionForm::renderForm($hashes);
+            },
+            'editor_script'   => 'mawiblah-subscription-form-block-js',
+        ]);
+
+        $audiences = array_map(function ($a) {
+            return ['hash' => $a->audienceHash, 'name' => $a->name];
+        }, Subscribers::getAllAudiences());
+
+        wp_register_script(
+            'mawiblah-subscription-form-block-js',
+            MAWIBLAH_PLUGIN_URL . '/assets/js/block/subscription-form.js',
+            ['wp-blocks', 'wp-element', 'wp-block-editor', 'wp-components'],
+            MAWIBLAH_VERSION
+        );
+        wp_localize_script('mawiblah-subscription-form-block-js', 'mawiblahSubscriptionBlock', [
+            'audiences' => $audiences,
+        ]);
     }
 
     public function my_custom_rest_api_nonce()

--- a/classes/Migrations.php
+++ b/classes/Migrations.php
@@ -7,15 +7,20 @@ class Migrations
     public static function run()
     {
         $currentVersion = get_option('mawiblah_db_version');
-        
+
         if (version_compare($currentVersion, '1.0.15', '<')) {
             self::migrateTo1015();
             update_option('mawiblah_db_version', '1.0.15');
         }
-        
+
         if (version_compare($currentVersion, '1.0.16', '<')) {
             self::migrateTo1016();
             update_option('mawiblah_db_version', '1.0.16');
+        }
+
+        if (version_compare($currentVersion, '1.0.17', '<')) {
+            self::migrateTo1017();
+            update_option('mawiblah_db_version', '1.0.17');
         }
     }
 
@@ -39,6 +44,39 @@ class Migrations
                 // Generate hash if missing entirely (should be handled by appendMeta but good for DB consistency)
                 $hash = Helpers::generateCampaignHash($campaign->ID);
                 update_post_meta($campaign->ID, 'campaignHash', $hash);
+            }
+        }
+    }
+
+    private static function migrateTo1017(): void
+    {
+        // Ensure both system audiences exist and have audienceHash set
+        $defaults = [
+            'Unsubed' => 'Audience for unsubscribed subscribers. Managed automatically.',
+            'Testers' => 'Audience for test campaign recipients. Managed automatically.',
+        ];
+
+        $taxonomy = Subscribers::postType() . '_category';
+
+        foreach ($defaults as $name => $description) {
+            $term = get_term_by('name', $name, $taxonomy);
+
+            if (!$term) {
+                $result = wp_insert_term($name, $taxonomy, ['description' => $description]);
+                if (is_wp_error($result)) {
+                    continue;
+                }
+                $term = get_term($result['term_id'], $taxonomy);
+            }
+
+            if (!$term || is_wp_error($term)) {
+                continue;
+            }
+
+            // Ensure audienceHash is set (same lazy logic as appendAudienceMeta)
+            $hash = get_term_meta($term->term_id, 'audienceHash', true);
+            if (!$hash) {
+                add_term_meta($term->term_id, 'audienceHash', md5((string) $term->term_id), true);
             }
         }
     }

--- a/classes/Migrations.php
+++ b/classes/Migrations.php
@@ -18,10 +18,6 @@ class Migrations
             update_option('mawiblah_db_version', '1.0.16');
         }
 
-        if (version_compare($currentVersion, '1.0.17', '<')) {
-            self::migrateTo1017();
-            update_option('mawiblah_db_version', '1.0.17');
-        }
     }
 
     private static function migrateTo1015()
@@ -44,39 +40,6 @@ class Migrations
                 // Generate hash if missing entirely (should be handled by appendMeta but good for DB consistency)
                 $hash = Helpers::generateCampaignHash($campaign->ID);
                 update_post_meta($campaign->ID, 'campaignHash', $hash);
-            }
-        }
-    }
-
-    private static function migrateTo1017(): void
-    {
-        // Ensure both system audiences exist and have audienceHash set
-        $defaults = [
-            'Unsubed' => 'Audience for unsubscribed subscribers. Managed automatically.',
-            'Testers' => 'Audience for test campaign recipients. Managed automatically.',
-        ];
-
-        $taxonomy = Subscribers::postType() . '_category';
-
-        foreach ($defaults as $name => $description) {
-            $term = get_term_by('name', $name, $taxonomy);
-
-            if (!$term) {
-                $result = wp_insert_term($name, $taxonomy, ['description' => $description]);
-                if (is_wp_error($result)) {
-                    continue;
-                }
-                $term = get_term($result['term_id'], $taxonomy);
-            }
-
-            if (!$term || is_wp_error($term)) {
-                continue;
-            }
-
-            // Ensure audienceHash is set (same lazy logic as appendAudienceMeta)
-            $hash = get_term_meta($term->term_id, 'audienceHash', true);
-            if (!$hash) {
-                add_term_meta($term->term_id, 'audienceHash', md5((string) $term->term_id), true);
             }
         }
     }

--- a/classes/Renderer.php
+++ b/classes/Renderer.php
@@ -185,4 +185,10 @@ class Renderer
         require MAWIBLAH_PLUGIN_DIR . "/templates/actions.php";
         exit;
     }
+
+    public static function help()
+    {
+        require MAWIBLAH_PLUGIN_DIR . "/templates/help.php";
+        exit;
+    }
 }

--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -348,6 +348,21 @@ msgstr ""
         return self::getOption('mawiblah-dont-disturb-threshold');
     }
 
+    public static function recaptchaEnabled(): bool
+    {
+        return self::getOption('mawiblah-recaptcha-enabled') === 'enabled';
+    }
+
+    public static function recaptchaSiteKey(): string
+    {
+        return (string) self::getOption('mawiblah-recaptcha-site-key');
+    }
+
+    public static function recaptchaSecretKey(): string
+    {
+        return (string) self::getOption('mawiblah-recaptcha-secret-key');
+    }
+
     public static function getOption($optionId)
     {
         // TODO: return default value if option not set

--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -363,6 +363,13 @@ msgstr ""
         return (string) self::getOption('mawiblah-recaptcha-secret-key');
     }
 
+    public static function recaptchaReady(): bool
+    {
+        return self::recaptchaEnabled()
+            && self::recaptchaSiteKey() !== ''
+            && self::recaptchaSecretKey() !== '';
+    }
+
     public static function getOption($optionId)
     {
         // TODO: return default value if option not set

--- a/classes/ShortCodes.php
+++ b/classes/ShortCodes.php
@@ -7,6 +7,7 @@ class ShortCodes
 
     public static function register()
     {
+        add_shortcode('mawiblah_subscribe_form', [ShortCodes::class, 'subscribeForm']);
         add_shortcode('mawiblah_title', [ShortCodes::class, 'title']);
         add_shortcode('mawiblah_content', [ShortCodes::class, 'content']);
 
@@ -108,6 +109,21 @@ class ShortCodes
     public static function endContent()
     {
         return __('We hope you enjoyed our monthly newsletter. If you have any questions or suggestions, feel free to contact us.', 'mawiblah');
+    }
+
+    public static function subscribeForm($atts): string
+    {
+        $atts = shortcode_atts(['audiences' => ''], $atts, 'mawiblah_subscribe_form');
+        $hashes = array_filter(array_map('trim', explode(',', $atts['audiences'])));
+
+        wp_enqueue_style('mawiblah-subscription-form-css', MAWIBLAH_PLUGIN_URL . '/assets/css/subscription-form.css', [], MAWIBLAH_VERSION);
+        wp_enqueue_script('mawiblah-subscription-form-js', MAWIBLAH_PLUGIN_URL . '/assets/js/subscription-form.js', [], MAWIBLAH_VERSION, true);
+        wp_localize_script('mawiblah-subscription-form-js', 'mawiblahSubscribeFormData', [
+            'restUrl'      => rest_url('mawiblah/v1/subscribe'),
+            'errorMessage' => __('Something went wrong. Please try again.', 'mawiblah'),
+        ]);
+
+        return SubscriptionForm::renderForm($hashes);
     }
 
     public static function unsubscribe()

--- a/classes/ShortCodes.php
+++ b/classes/ShortCodes.php
@@ -114,7 +114,7 @@ class ShortCodes
     public static function subscribeForm($atts): string
     {
         $atts = shortcode_atts(['audiences' => ''], $atts, 'mawiblah_subscribe_form');
-        $hashes = array_filter(array_map('trim', explode(',', $atts['audiences'])));
+        $hashes = array_values(array_filter(array_map('sanitize_text_field', array_map('trim', explode(',', $atts['audiences'])))));
 
         wp_enqueue_style('mawiblah-subscription-form-css', MAWIBLAH_PLUGIN_URL . '/assets/css/subscription-form.css', [], MAWIBLAH_VERSION);
         wp_enqueue_script('mawiblah-subscription-form-js', MAWIBLAH_PLUGIN_URL . '/assets/js/subscription-form.js', [], MAWIBLAH_VERSION, true);

--- a/classes/ShortCodes.php
+++ b/classes/ShortCodes.php
@@ -113,8 +113,20 @@ class ShortCodes
 
     public static function subscribeForm($atts): string
     {
-        $atts = shortcode_atts(['audiences' => ''], $atts, 'mawiblah_subscribe_form');
+        $atts = shortcode_atts([
+            'audiences'   => '',
+            'label'       => '',
+            'placeholder' => '',
+            'button'      => '',
+        ], $atts, 'mawiblah_subscribe_form');
+
         $hashes = array_values(array_filter(array_map('sanitize_text_field', array_map('trim', explode(',', $atts['audiences'])))));
+
+        $options = array_filter([
+            'label'       => sanitize_text_field($atts['label']),
+            'placeholder' => sanitize_text_field($atts['placeholder']),
+            'buttonText'  => sanitize_text_field($atts['button']),
+        ]);
 
         wp_enqueue_style('mawiblah-subscription-form-css', MAWIBLAH_PLUGIN_URL . '/assets/css/subscription-form.css', [], MAWIBLAH_VERSION);
         wp_enqueue_script('mawiblah-subscription-form-js', MAWIBLAH_PLUGIN_URL . '/assets/js/subscription-form.js', [], MAWIBLAH_VERSION, true);
@@ -123,7 +135,7 @@ class ShortCodes
             'errorMessage' => __('Something went wrong. Please try again.', 'mawiblah'),
         ]);
 
-        return SubscriptionForm::renderForm($hashes);
+        return SubscriptionForm::renderForm($hashes, $options);
     }
 
     public static function unsubscribe()

--- a/classes/ShortCodes.php
+++ b/classes/ShortCodes.php
@@ -118,14 +118,18 @@ class ShortCodes
             'label'       => '',
             'placeholder' => '',
             'button'      => '',
+            'success'     => '',
+            'error'       => '',
         ], $atts, 'mawiblah_subscribe_form');
 
         $hashes = array_values(array_filter(array_map('sanitize_text_field', array_map('trim', explode(',', $atts['audiences'])))));
 
         $options = array_filter([
-            'label'       => sanitize_text_field($atts['label']),
-            'placeholder' => sanitize_text_field($atts['placeholder']),
-            'buttonText'  => sanitize_text_field($atts['button']),
+            'label'          => sanitize_text_field($atts['label']),
+            'placeholder'    => sanitize_text_field($atts['placeholder']),
+            'buttonText'     => sanitize_text_field($atts['button']),
+            'successMessage' => sanitize_text_field($atts['success']),
+            'errorMessage'   => sanitize_text_field($atts['error']),
         ]);
 
         wp_enqueue_style('mawiblah-subscription-form-css', MAWIBLAH_PLUGIN_URL . '/assets/css/subscription-form.css', [], MAWIBLAH_VERSION);

--- a/classes/Subscribers.php
+++ b/classes/Subscribers.php
@@ -492,7 +492,11 @@ class Subscribers
     {
         $term = get_term_by('name', 'Testers', Subscribers::postType() . '_category');
         if (!$term) {
-            $term = wp_insert_term('Testers', Subscribers::postType() . '_category');
+            $result = wp_insert_term('Testers', Subscribers::postType() . '_category');
+            if (is_wp_error($result)) {
+                return null;
+            }
+            $term = get_term($result['term_id'], Subscribers::postType() . '_category');
         }
         return $term;
     }

--- a/classes/Subscribers.php
+++ b/classes/Subscribers.php
@@ -9,7 +9,14 @@ class Subscribers
     public static function init()
     {
         self::registerPostType();
+        self::ensureDefaultAudiences();
         add_action('add_meta_boxes', [self::class, 'addMetaBoxes']);
+    }
+
+    public static function ensureDefaultAudiences(): void
+    {
+        self::unsubedAudience();
+        self::testerAudience();
     }
 
     public static function addMetaBoxes()

--- a/classes/Subscribers.php
+++ b/classes/Subscribers.php
@@ -214,7 +214,26 @@ class Subscribers
         $audience->gravityFormsId = get_term_meta($audience->term_id, 'gravityFormsId', true);
         $audience->lastSyncDate = get_term_meta($audience->term_id, 'lastSyncDate', true);
         $audience->id = $audience->term_id;
+
+        $audienceHash = get_term_meta($audience->term_id, 'audienceHash', true);
+        if (!$audienceHash) {
+            $audienceHash = md5((string) $audience->term_id);
+            add_term_meta($audience->term_id, 'audienceHash', $audienceHash, true);
+        }
+        $audience->audienceHash = $audienceHash;
+
         return $audience;
+    }
+
+    public static function getAudienceByHash(string $audienceHash): ?object
+    {
+        $audiences = self::getAllAudiences();
+        foreach ($audiences as $audience) {
+            if ($audience->audienceHash === $audienceHash) {
+                return $audience;
+            }
+        }
+        return null;
     }
 
     public static function getAudience($audienceId)

--- a/classes/Subscribers.php
+++ b/classes/Subscribers.php
@@ -307,16 +307,18 @@ class Subscribers
 
     public static function addSubscriber(string $email, string $subscriberHash = ""): object
     {
+        $existing = self::getSubscriber($email);
+        if ($existing) {
+            return $existing;
+        }
 
-        // Prepare the post data
         $post_data = [
-            'post_title' => $email,
+            'post_title'   => $email,
             'post_content' => '',
-            'post_status' => 'publish',
-            'post_type' => self::postType(), // Replace with your custom post type
+            'post_status'  => 'publish',
+            'post_type'    => self::postType(),
         ];
 
-        // Insert the post into the database
         $post_id = wp_insert_post($post_data);
 
         if (!is_wp_error($post_id)) {

--- a/classes/SubscriptionForm.php
+++ b/classes/SubscriptionForm.php
@@ -48,7 +48,20 @@ class SubscriptionForm
             }
         }
 
-        // Email validation
+        return self::subscribeByEmail($email, $audienceHashes);
+    }
+
+    /**
+     * Subscribe an email address to one or more audiences.
+     *
+     * Safe to call from any PHP code (Gravity Forms callbacks, WP-CLI, etc.).
+     * Returns ['status' => 'ok'|'error', 'message' => string].
+     *
+     * Fires the `mawiblah_subscribed` action on success:
+     *   do_action('mawiblah_subscribed', string $email, array $audienceHashes, object $subscriber)
+     */
+    public static function subscribeByEmail(string $email, array $audienceHashes = []): array
+    {
         if (!is_email($email)) {
             return ['status' => 'error', 'message' => __('Invalid email address.', 'mawiblah')];
         }
@@ -82,6 +95,8 @@ class SubscriptionForm
                 Subscribers::addSubscriberToAudience($subscriber->id, $audienceId);
             }
         }
+
+        do_action('mawiblah_subscribed', $email, $audienceHashes, $subscriber);
 
         return ['status' => 'ok', 'message' => __('You are now subscribed!', 'mawiblah')];
     }

--- a/classes/SubscriptionForm.php
+++ b/classes/SubscriptionForm.php
@@ -14,10 +14,13 @@ class SubscriptionForm
         }
     }
 
-    public static function renderForm(array $audienceHashes = []): string
+    public static function renderForm(array $audienceHashes = [], array $options = []): string
     {
-        $siteKey    = Settings::recaptchaSiteKey();
-        $recaptcha  = Settings::recaptchaEnabled() && $siteKey;
+        $siteKey     = Settings::recaptchaSiteKey();
+        $recaptcha   = Settings::recaptchaEnabled() && $siteKey;
+        $label       = $options['label']       ?? __('Email', 'mawiblah');
+        $placeholder = $options['placeholder'] ?? __('your@email.com', 'mawiblah');
+        $buttonText  = $options['buttonText']  ?? __('Subscribe', 'mawiblah');
         ob_start();
         include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/form.php';
         return ob_get_clean();

--- a/classes/SubscriptionForm.php
+++ b/classes/SubscriptionForm.php
@@ -107,18 +107,28 @@ class SubscriptionForm
         $resubToken     = sanitize_text_field($_GET['resubToken'] ?? '');
         $audienceParam  = sanitize_text_field($_GET['audiences'] ?? '');
 
+        $result = self::confirmResubscribe($subscriberHash, $resubToken, $audienceParam);
+
+        if ($result) {
+            include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/resubscribe-confirm.php';
+        } else {
+            include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/resubscribe-invalid.php';
+        }
+        exit;
+    }
+
+    public static function confirmResubscribe(string $subscriberHash, string $resubToken, string $audienceParam): bool
+    {
         $subscriber = Subscribers::getSubscriberBySubscriberHash($subscriberHash);
 
         if (!$subscriber) {
-            include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/resubscribe-invalid.php';
-            exit;
+            return false;
         }
 
         $expectedToken = Subscribers::getUnsubToken($subscriber->id, $subscriber->email);
 
         if ($resubToken !== $expectedToken) {
-            include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/resubscribe-invalid.php';
-            exit;
+            return false;
         }
 
         // Clear unsubed flag
@@ -141,8 +151,7 @@ class SubscriptionForm
             }
         }
 
-        include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/resubscribe-confirm.php';
-        exit;
+        return true;
     }
 
     private static function verifyRecaptcha(string $token): bool

--- a/classes/SubscriptionForm.php
+++ b/classes/SubscriptionForm.php
@@ -17,7 +17,7 @@ class SubscriptionForm
     public static function renderForm(array $audienceHashes = [], array $options = []): string
     {
         $siteKey        = Settings::recaptchaSiteKey();
-        $recaptcha      = Settings::recaptchaEnabled() && $siteKey;
+        $recaptcha      = Settings::recaptchaReady();
         $label          = $options['label']          ?? __('Email', 'mawiblah');
         $placeholder    = $options['placeholder']    ?? __('your@email.com', 'mawiblah');
         $buttonText     = $options['buttonText']     ?? __('Subscribe', 'mawiblah');
@@ -42,7 +42,7 @@ class SubscriptionForm
         }
 
         // reCAPTCHA v3
-        if (Settings::recaptchaEnabled()) {
+        if (Settings::recaptchaReady()) {
             if (!self::verifyRecaptcha($recaptchaToken)) {
                 return ['status' => 'error', 'message' => __('Verification failed. Please try again.', 'mawiblah')];
             }

--- a/classes/SubscriptionForm.php
+++ b/classes/SubscriptionForm.php
@@ -16,11 +16,13 @@ class SubscriptionForm
 
     public static function renderForm(array $audienceHashes = [], array $options = []): string
     {
-        $siteKey     = Settings::recaptchaSiteKey();
-        $recaptcha   = Settings::recaptchaEnabled() && $siteKey;
-        $label       = $options['label']       ?? __('Email', 'mawiblah');
-        $placeholder = $options['placeholder'] ?? __('your@email.com', 'mawiblah');
-        $buttonText  = $options['buttonText']  ?? __('Subscribe', 'mawiblah');
+        $siteKey        = Settings::recaptchaSiteKey();
+        $recaptcha      = Settings::recaptchaEnabled() && $siteKey;
+        $label          = $options['label']          ?? __('Email', 'mawiblah');
+        $placeholder    = $options['placeholder']    ?? __('your@email.com', 'mawiblah');
+        $buttonText     = $options['buttonText']     ?? __('Subscribe', 'mawiblah');
+        $successMessage = $options['successMessage'] ?? '';
+        $errorMessage   = $options['errorMessage']   ?? '';
         ob_start();
         include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/form.php';
         return ob_get_clean();

--- a/classes/SubscriptionForm.php
+++ b/classes/SubscriptionForm.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace Mawiblah;
+
+class SubscriptionForm
+{
+    const RECAPTCHA_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
+    const RECAPTCHA_THRESHOLD  = 0.5;
+
+    public static function init(): void
+    {
+        if (isset($_GET['mawiblah-resubscribe'])) {
+            self::handleResubscribeConfirmation();
+        }
+    }
+
+    public static function renderForm(array $audienceHashes = []): string
+    {
+        $siteKey    = Settings::recaptchaSiteKey();
+        $recaptcha  = Settings::recaptchaEnabled() && $siteKey;
+        ob_start();
+        include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/form.php';
+        return ob_get_clean();
+    }
+
+    public static function subscribe(\WP_REST_Request $request): array
+    {
+        $body           = $request->get_json_params();
+        $email          = sanitize_email($body['email'] ?? '');
+        $audienceHashes = array_map('sanitize_text_field', (array) ($body['audienceHashes'] ?? []));
+        $honeypot       = $body['honeypot'] ?? '';
+        $recaptchaToken = sanitize_text_field($body['recaptchaToken'] ?? '');
+
+        // Honeypot — silently succeed so bots think it worked
+        if (!empty($honeypot)) {
+            return ['status' => 'ok', 'message' => __('You are now subscribed!', 'mawiblah')];
+        }
+
+        // reCAPTCHA v3
+        if (Settings::recaptchaEnabled()) {
+            if (!self::verifyRecaptcha($recaptchaToken)) {
+                return ['status' => 'error', 'message' => __('Verification failed. Please try again.', 'mawiblah')];
+            }
+        }
+
+        // Email validation
+        if (!is_email($email)) {
+            return ['status' => 'error', 'message' => __('Invalid email address.', 'mawiblah')];
+        }
+
+        // Resolve audienceHashes → term IDs
+        $audienceIds = [];
+        foreach ($audienceHashes as $hash) {
+            $audience = Subscribers::getAudienceByHash($hash);
+            if ($audience) {
+                $audienceIds[] = (int) $audience->term_id;
+            }
+        }
+
+        $subscriber = Subscribers::getSubscriber($email);
+
+        // Unsubscribed — send re-subscribe confirmation email
+        if ($subscriber && $subscriber->unsubed) {
+            self::sendResubscribeEmail($subscriber, $audienceIds);
+            return ['status' => 'ok', 'message' => __('Check your inbox to confirm your subscription.', 'mawiblah')];
+        }
+
+        // New subscriber
+        if (!$subscriber) {
+            $subscriber = Subscribers::addSubscriber($email);
+        }
+
+        // Add to audiences (only those not already assigned)
+        foreach ($audienceIds as $audienceId) {
+            $terms = wp_get_post_terms($subscriber->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
+            if (!in_array($audienceId, $terms)) {
+                Subscribers::addSubscriberToAudience($subscriber->id, $audienceId);
+            }
+        }
+
+        return ['status' => 'ok', 'message' => __('You are now subscribed!', 'mawiblah')];
+    }
+
+    private static function sendResubscribeEmail(object $subscriber, array $audienceIds): void
+    {
+        $token        = Subscribers::getUnsubToken($subscriber->id, $subscriber->email);
+        $audienceParam = implode(',', array_map('strval', $audienceIds));
+        $confirmUrl   = add_query_arg([
+            'mawiblah-resubscribe' => '1',
+            'subscriber'           => $subscriber->subscriberHash,
+            'resubToken'           => $token,
+            'audiences'            => $audienceParam,
+        ], get_site_url());
+
+        $subject = sprintf(__('Confirm your subscription to %s', 'mawiblah'), get_bloginfo('name'));
+        $body    = sprintf(
+            __("Hi,\n\nClick the link below to confirm your re-subscription:\n\n%s\n\nIf you did not request this, please ignore this email.", 'mawiblah'),
+            $confirmUrl
+        );
+
+        wp_mail($subscriber->email, $subject, $body);
+    }
+
+    private static function handleResubscribeConfirmation(): void
+    {
+        $subscriberHash = sanitize_text_field($_GET['subscriber'] ?? '');
+        $resubToken     = sanitize_text_field($_GET['resubToken'] ?? '');
+        $audienceParam  = sanitize_text_field($_GET['audiences'] ?? '');
+
+        $subscriber = Subscribers::getSubscriberBySubscriberHash($subscriberHash);
+
+        if (!$subscriber) {
+            include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/resubscribe-invalid.php';
+            exit;
+        }
+
+        $expectedToken = Subscribers::getUnsubToken($subscriber->id, $subscriber->email);
+
+        if ($resubToken !== $expectedToken) {
+            include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/resubscribe-invalid.php';
+            exit;
+        }
+
+        // Clear unsubed flag
+        update_post_meta($subscriber->id, 'unsubed', false);
+        delete_post_meta($subscriber->id, 'unsub_time');
+
+        // Remove from unsubbed audience
+        $unsubedAudience = Subscribers::unsubedAudience();
+        if ($unsubedAudience) {
+            $terms = wp_get_post_terms($subscriber->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
+            $terms = array_diff($terms, [$unsubedAudience->term_id]);
+            wp_set_post_terms($subscriber->id, array_values($terms), Subscribers::postType() . '_category');
+        }
+
+        // Add to requested audiences
+        if (!empty($audienceParam)) {
+            $audienceIds = array_filter(array_map('intval', explode(',', $audienceParam)));
+            foreach ($audienceIds as $audienceId) {
+                Subscribers::addSubscriberToAudience($subscriber->id, $audienceId);
+            }
+        }
+
+        include MAWIBLAH_TEMPLATE_DIR . '/subscription-form/resubscribe-confirm.php';
+        exit;
+    }
+
+    private static function verifyRecaptcha(string $token): bool
+    {
+        if (empty($token)) {
+            return false;
+        }
+
+        $response = wp_remote_post(self::RECAPTCHA_VERIFY_URL, [
+            'body' => [
+                'secret'   => Settings::recaptchaSecretKey(),
+                'response' => $token,
+            ],
+        ]);
+
+        if (is_wp_error($response)) {
+            return false;
+        }
+
+        $data = json_decode(wp_remote_retrieve_body($response), true);
+
+        return isset($data['success'], $data['score'])
+            && $data['success'] === true
+            && $data['score'] >= self::RECAPTCHA_THRESHOLD;
+    }
+}

--- a/classes/Tests.php
+++ b/classes/Tests.php
@@ -46,7 +46,8 @@ class Tests
             'unsubscribe'       => 'Unsubscribe Flow',
             'click-tracking'    => 'Click Tracking (triple-count)',
             'subscription-form' => 'Subscription Form',
-            'default-audiences' => 'Default Audiences (Unsubed + Testers)',
+            'default-audiences'          => 'Default Audiences (Unsubed + Testers)',
+            'programmatic-subscribe'     => 'Programmatic Subscribe (mawiblah_subscribe hook)',
         ];
     }
 
@@ -66,8 +67,9 @@ class Tests
             'unsubscribe'       => self::unsubscribeScenario(),
             'click-tracking'    => self::clickTrackingScenario(),
             'subscription-form' => self::subscriptionFormScenario(),
-            'default-audiences' => self::defaultAudiencesScenario(),
-            default             => self::echoResult('Unknown scenario: ' . $scenario, 'error'),
+            'default-audiences'          => self::defaultAudiencesScenario(),
+            'programmatic-subscribe'     => self::programmaticSubscribeScenario(),
+            default                      => self::echoResult('Unknown scenario: ' . $scenario, 'error'),
         };
     }
 
@@ -519,5 +521,102 @@ class Tests
         $testers = Subscribers::testerAudience();
         $distinct = $unsubed && $testers && $unsubed->term_id !== $testers->term_id;
         self::echoResult($distinct ? 'Distinct IDs' : 'Same term or missing', $distinct ? 'success' : 'error');
+    }
+
+    // -------------------------------------------------------------------------
+    // Programmatic Subscribe
+    // -------------------------------------------------------------------------
+
+    public static function programmaticSubscribeScenario(): void
+    {
+        self::echoHeading('Programmatic Subscribe');
+
+        $email    = 'hooktest@mawiblah.test';
+        $taxonomy = Subscribers::postType() . '_category';
+        self::deleteSubscribersByEmail($email);
+
+        $t1 = wp_insert_term('Hook Test Audience 1', $taxonomy);
+        $t2 = wp_insert_term('Hook Test Audience 2', $taxonomy);
+
+        $aud1Id = is_wp_error($t1) ? null : $t1['term_id'];
+        $aud2Id = is_wp_error($t2) ? null : $t2['term_id'];
+        $aud1   = $aud1Id ? Subscribers::getAudience($aud1Id) : null;
+        $aud2   = $aud2Id ? Subscribers::getAudience($aud2Id) : null;
+        $hash1  = $aud1->audienceHash ?? null;
+        $hash2  = $aud2->audienceHash ?? null;
+        $hashes = array_values(array_filter([$hash1, $hash2]));
+
+        // --- invalid email -------------------------------------------------------
+        self::echoTitle('Invalid email returns error');
+        $res = mawiblah_subscribe('not-an-email');
+        self::echoResult($res['status'] === 'error' ? 'Correctly returned error' : 'Should be error', $res['status'] === 'error' ? 'success' : 'error');
+
+        // --- new subscriber ------------------------------------------------------
+        self::echoTitle('New email → subscriber created, added to both audiences');
+        $res = mawiblah_subscribe($email, $hashes);
+        $sub = Subscribers::getSubscriber($email);
+        $ok  = $res['status'] === 'ok' && $sub !== null;
+        self::echoResult($ok ? 'Subscriber created' : 'Failed — ' . $res['message'], $ok ? 'success' : 'error');
+
+        if ($sub && $aud1Id && $aud2Id) {
+            $terms = wp_get_post_terms($sub->id, $taxonomy, ['fields' => 'ids']);
+            $inBoth = in_array($aud1Id, $terms) && in_array($aud2Id, $terms);
+            self::echoResult($inBoth ? 'Added to both audiences' : 'Missing audience (terms: ' . implode(',', $terms) . ')', $inBoth ? 'success' : 'error');
+        }
+
+        // --- no duplicate --------------------------------------------------------
+        self::echoTitle('Same email again → ok, no duplicate subscriber');
+        $res  = mawiblah_subscribe($email, $hashes);
+        $dups = get_posts(['post_type' => Subscribers::postType(), 'title' => $email, 'posts_per_page' => -1]);
+        $ok   = $res['status'] === 'ok' && count($dups) === 1;
+        self::echoResult($ok ? 'No duplicate' : 'Failed (' . count($dups) . ' records)', $ok ? 'success' : 'error');
+
+        // --- mawiblah_subscribed action hook -------------------------------------
+        self::echoTitle('mawiblah_subscribed action fires with correct arguments');
+        self::deleteSubscribersByEmail($email);
+
+        $hookFired      = false;
+        $hookEmail      = null;
+        $hookHashes     = null;
+        $hookSubscriber = null;
+
+        $listener = function (string $e, array $h, object $s) use (&$hookFired, &$hookEmail, &$hookHashes, &$hookSubscriber) {
+            $hookFired      = true;
+            $hookEmail      = $e;
+            $hookHashes     = $h;
+            $hookSubscriber = $s;
+        };
+        add_action('mawiblah_subscribed', $listener, 10, 3);
+
+        mawiblah_subscribe($email, $hashes);
+
+        remove_action('mawiblah_subscribed', $listener, 10);
+
+        $ok = $hookFired && $hookEmail === $email && $hookHashes === $hashes && $hookSubscriber !== null;
+        self::echoResult($ok ? 'Hook fired with correct args' : 'Hook not fired or wrong args', $ok ? 'success' : 'error');
+
+        // --- partial overlap — only missing audience added -----------------------
+        self::echoTitle('Partial overlap → only missing audience added');
+        $sub = Subscribers::getSubscriber($email);
+        if ($sub && $aud1Id && $aud2Id) {
+            // Remove aud2 so subscriber is only in aud1
+            $currentTerms = wp_get_post_terms($sub->id, $taxonomy, ['fields' => 'ids']);
+            wp_set_post_terms($sub->id, array_diff($currentTerms, [$aud2Id]), $taxonomy);
+
+            // Re-subscribe to both
+            mawiblah_subscribe($email, $hashes);
+
+            $terms  = wp_get_post_terms($sub->id, $taxonomy, ['fields' => 'ids']);
+            $inBoth = in_array($aud1Id, $terms) && in_array($aud2Id, $terms);
+            self::echoResult($inBoth ? 'Both audiences present' : 'Missing audience after re-subscribe', $inBoth ? 'success' : 'error');
+        } else {
+            self::echoResult('Skipped — subscriber or audiences missing', 'error');
+        }
+
+        // --- cleanup -------------------------------------------------------------
+        self::deleteSubscribersByEmail($email);
+        if ($aud1Id) wp_delete_term($aud1Id, $taxonomy);
+        if ($aud2Id) wp_delete_term($aud2Id, $taxonomy);
+        self::echoResult('Cleaned up', 'success');
     }
 }

--- a/classes/Tests.php
+++ b/classes/Tests.php
@@ -22,6 +22,19 @@ class Tests
         }
     }
 
+    private static function deleteSubscribersByEmail(string $email): void
+    {
+        $posts = get_posts([
+            'post_type'      => Subscribers::postType(),
+            'title'          => $email,
+            'posts_per_page' => -1,
+            'post_status'    => 'any',
+        ]);
+        foreach ($posts as $p) {
+            wp_delete_post($p->ID, true);
+        }
+    }
+
     public static function scenarios(): array
     {
         return [
@@ -236,6 +249,7 @@ class Tests
         self::echoHeading('Subscriber CRUD & Audience Hash');
 
         $email = 'subscribertest@mawiblah.test';
+        self::deleteSubscribersByEmail($email);
 
         self::echoTitle('addSubscriber creates subscriber');
         $sub = Subscribers::addSubscriber($email);
@@ -286,7 +300,7 @@ class Tests
         self::echoResult(Subscribers::isEmailSent($sub->id, $cId) ? 'Correctly true' : 'Should be true', Subscribers::isEmailSent($sub->id, $cId) ? 'success' : 'error');
 
         Campaigns::deleteCampaign($cId);
-        wp_delete_post($sub->id, true);
+        self::deleteSubscribersByEmail($email);
         self::echoResult('Cleaned up', 'success');
     }
 
@@ -299,6 +313,7 @@ class Tests
         self::echoHeading('Unsubscribe Flow');
 
         $email = 'unsubtest@mawiblah.test';
+        self::deleteSubscribersByEmail($email);
         $sub   = Subscribers::addSubscriber($email);
         $cId   = Campaigns::addCampaign('Unsub Test Campaign', 'Subject', 'Title', 'Content', [], 'test-template');
         $token = Subscribers::getUnsubToken($sub->id, $email);
@@ -326,7 +341,7 @@ class Tests
         self::echoResult($after === $before + 1 ? 'Counter incremented' : 'Not incremented', $after === $before + 1 ? 'success' : 'error');
 
         Campaigns::deleteCampaign($cId);
-        wp_delete_post($sub->id, true);
+        self::deleteSubscribersByEmail($email);
         self::echoResult('Cleaned up', 'success');
     }
 
@@ -397,6 +412,8 @@ class Tests
         self::echoHeading('Subscription Form');
 
         $email = 'formtest@mawiblah.test';
+        self::deleteSubscribersByEmail($email);
+        self::deleteSubscribersByEmail('honeypot@mawiblah.test');
 
         $aud1   = wp_insert_term('Form Test Audience 1', Subscribers::postType() . '_category');
         $aud2   = wp_insert_term('Form Test Audience 2', Subscribers::postType() . '_category');
@@ -461,7 +478,8 @@ class Tests
         self::echoResult($rejected ? 'Correctly rejected' : 'Should be rejected', $rejected ? 'success' : 'error');
 
         // Cleanup
-        wp_delete_post($sub->id, true);
+        self::deleteSubscribersByEmail($email);
+        self::deleteSubscribersByEmail('honeypot@mawiblah.test');
         if ($aud1Id) wp_delete_term($aud1Id, Subscribers::postType() . '_category');
         if ($aud2Id) wp_delete_term($aud2Id, Subscribers::postType() . '_category');
         self::echoResult('Cleaned up', 'success');

--- a/classes/Tests.php
+++ b/classes/Tests.php
@@ -33,6 +33,7 @@ class Tests
             'unsubscribe'       => 'Unsubscribe Flow',
             'click-tracking'    => 'Click Tracking (triple-count)',
             'subscription-form' => 'Subscription Form',
+            'default-audiences' => 'Default Audiences (Unsubed + Testers)',
         ];
     }
 
@@ -52,6 +53,7 @@ class Tests
             'unsubscribe'       => self::unsubscribeScenario(),
             'click-tracking'    => self::clickTrackingScenario(),
             'subscription-form' => self::subscriptionFormScenario(),
+            'default-audiences' => self::defaultAudiencesScenario(),
             default             => self::echoResult('Unknown scenario: ' . $scenario, 'error'),
         };
     }
@@ -463,5 +465,41 @@ class Tests
         if ($aud1Id) wp_delete_term($aud1Id, Subscribers::postType() . '_category');
         if ($aud2Id) wp_delete_term($aud2Id, Subscribers::postType() . '_category');
         self::echoResult('Cleaned up', 'success');
+    }
+
+    // -------------------------------------------------------------------------
+    // Default Audiences
+    // -------------------------------------------------------------------------
+
+    public static function defaultAudiencesScenario(): void
+    {
+        self::echoHeading('Default Audiences');
+
+        $taxonomy = Subscribers::postType() . '_category';
+
+        foreach (['Unsubed' => 'unsubedAudience', 'Testers' => 'testerAudience'] as $name => $method) {
+            self::echoTitle($name . ' audience exists');
+            $term = get_term_by('name', $name, $taxonomy);
+            self::echoResult($term ? 'Exists (ID ' . $term->term_id . ')' : 'Missing', $term ? 'success' : 'error');
+
+            self::echoTitle($name . ' — ' . $method . '() returns a term object');
+            $result = Subscribers::$method();
+            $ok = $result && !is_wp_error($result) && isset($result->term_id);
+            self::echoResult($ok ? 'Returns term object (ID ' . $result->term_id . ')' : 'Returned non-object', $ok ? 'success' : 'error', $ok ? null : $result);
+
+            self::echoTitle($name . ' — audienceHash is set');
+            if ($ok) {
+                $hash = get_term_meta($result->term_id, 'audienceHash', true);
+                self::echoResult($hash ? 'Hash: ' . $hash : 'No hash', $hash ? 'success' : 'error');
+            } else {
+                self::echoResult('Skipped — term not found', 'error');
+            }
+        }
+
+        self::echoTitle('Unsubed audience is distinct from Testers');
+        $unsubed = Subscribers::unsubedAudience();
+        $testers = Subscribers::testerAudience();
+        $distinct = $unsubed && $testers && $unsubed->term_id !== $testers->term_id;
+        self::echoResult($distinct ? 'Distinct IDs' : 'Same term or missing', $distinct ? 'success' : 'error');
     }
 }

--- a/classes/Tests.php
+++ b/classes/Tests.php
@@ -6,100 +6,462 @@ class Tests
 {
     public static function echoHeading(string $title): void
     {
-        echo "<h2>$title</h2>";
+        echo '<h2>' . esc_html($title) . '</h2>';
     }
 
     public static function echoTitle(string $title): void
     {
-        echo "<h3>$title</h3>";
+        echo '<h3>' . esc_html($title) . '</h3>';
     }
 
-    public static function echoResult($resultMessage, $resultType, $debug=null): void
+    public static function echoResult(string $resultMessage, string $resultType, $debug = null): void
     {
-        echo "<p class='mawiblah-$resultType'>$resultMessage</p>";
+        echo '<p class="mawiblah-' . esc_attr($resultType) . '">' . esc_html($resultMessage) . '</p>';
         if ($debug) {
-            echo "<p class='mawiblah-debug'>".print_r($debug)."<p>";
+            echo '<pre class="mawiblah-debug">' . esc_html(print_r($debug, true)) . '</pre>';
         }
     }
 
-    public static function getCampaignTitle(): string
+    public static function scenarios(): array
     {
-        return 'Mawiblah Test Campaing';
+        return [
+            'campaigns'         => 'Campaign CRUD',
+            'campaign-workflow' => 'Campaign Workflow (test / approve / start / finish)',
+            'campaign-counters' => 'Campaign Counters',
+            'campaign-template' => 'Campaign Template & Placeholders',
+            'subscribers'       => 'Subscriber CRUD & Audience Hash',
+            'unsubscribe'       => 'Unsubscribe Flow',
+            'click-tracking'    => 'Click Tracking (triple-count)',
+            'subscription-form' => 'Subscription Form',
+        ];
     }
-    public static function tests(): void
+
+    public static function run(string $scenario): void
     {
-
-        $campaignTitle = self::getCampaignTitle();
-        $campaignTitle2 = self::getCampaignTitle()." ---2";
-        $campaignTitle3 = self::getCampaignTitle()." ---3";
-
-        if (current_user_can('editor') || current_user_can('administrator')) {
-            // test that adds comaingn to posts
-
-            $campaignsAtTheStartOfTheTest = Campaigns::getCampaigns();
-
-            self::echoHeading("Campaigns self tests");
-
-            self::echoTitle('Mawiblah Test Campaing');
-            $result = Campaigns::addCampaign($campaignTitle, 'Test subject',  'Test content title','Test content', ['Test audience'], 'Test template');
-            $tiId = $result;
-            if ($result) {
-                self::echoResult('Campaign added', 'success');
-            } else {
-                self::echoResult('Campaign not added', 'error');
-            }
-
-            $result = Campaigns::addCampaign($campaignTitle3, 'Test subject', 'Test content title','Test content', ['Test audience'], 'Test template');
-            $t3Id = $result;
-
-            // check if newly created campaign exists
-            self::echoTitle('Check if newly created campaign exists');
-            $campaign = Campaigns::getCampaign($campaignTitle);
-            if ($campaign && $campaign->post_title === $campaignTitle) {
-                self::echoResult('Campaign exists', 'success');
-            } else {
-                self::echoResult('Campaign does not exist', 'error');
-            }
-
-            //check the campaign that should not exist
-            self::echoTitle('Check the campaign that should not exist');
-            $campaign = Campaigns::getCampaign($campaignTitle2);
-            if ($campaign === null) {
-                self::echoResult('Campaign does not exist', 'success');
-            } else {
-                self::echoResult('Campaign exists, but should not', 'error', $campaign);
-            }
-
-
-            // get campaings should be atleaste tow
-            self::echoTitle('Get campaings');
-            $campaigns = Campaigns::getCampaigns();
-            if (count($campaigns) >= 2) {
-                self::echoResult('Campaigns found - '.count($campaigns), 'success');
-            } else {
-                self::echoResult('No campaigns found, wrong count', 'error');
-            }
-
-            self::echoTitle('Exactly two campaigns where created');
-            if (count($campaigns) - count($campaignsAtTheStartOfTheTest) === 2) {
-                self::echoResult('Campaigns at the start - '.count($campaignsAtTheStartOfTheTest).' and campaigns before deletion '.count($campaigns), 'success');
-            } else {
-                self::echoResult('Wrong count, test failed. At the start - '.count($campaignsAtTheStartOfTheTest).' and campaigns before deletion '.count($campaigns), 'error');
-            }
-
-
-            // remove compaings
-            self::echoTitle('Remove test campaings that was created');
-            Campaigns::deleteCampaign($tiId);
-            Campaigns::deleteCampaign($t3Id);
-
-            $campaigns = Campaigns::getCampaigns();
-            if (count($campaigns) === count($campaignsAtTheStartOfTheTest)) {
-                self::echoResult('Campaigns removed', 'success');
-            } else {
-                self::echoResult('Campaigns not removed', 'error');
-            }
-
+        if (!current_user_can('administrator')) {
+            self::echoResult('Access denied.', 'error');
+            return;
         }
+
+        match ($scenario) {
+            'campaigns'         => self::campaignScenario(),
+            'campaign-workflow' => self::campaignWorkflowScenario(),
+            'campaign-counters' => self::campaignCountersScenario(),
+            'campaign-template' => self::campaignTemplateScenario(),
+            'subscribers'       => self::subscriberScenario(),
+            'unsubscribe'       => self::unsubscribeScenario(),
+            'click-tracking'    => self::clickTrackingScenario(),
+            'subscription-form' => self::subscriptionFormScenario(),
+            default             => self::echoResult('Unknown scenario: ' . $scenario, 'error'),
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Campaign CRUD
+    // -------------------------------------------------------------------------
+
+    public static function campaignScenario(): void
+    {
+        self::echoHeading('Campaign CRUD');
+
+        $title1   = 'Mawiblah Test Campaign';
+        $title2   = 'Mawiblah Test Campaign ---2';
+        $baseline = count(Campaigns::getCampaigns());
+
+        self::echoTitle('Add campaign');
+        $id1 = Campaigns::addCampaign($title1, 'Subject', 'Content Title', 'Content', [], 'test-template');
+        self::echoResult($id1 ? 'Campaign added (ID ' . $id1 . ')' : 'Campaign not added', $id1 ? 'success' : 'error');
+
+        $id2 = Campaigns::addCampaign($title2, 'Subject', 'Content Title', 'Content', [], 'test-template');
+
+        self::echoTitle('getCampaign finds by title');
+        $found = Campaigns::getCampaign($title1);
+        $ok = $found && $found->post_title === $title1;
+        self::echoResult($ok ? 'Found' : 'Not found', $ok ? 'success' : 'error');
+
+        self::echoTitle('getCampaign returns null for missing title');
+        $notFound = Campaigns::getCampaign('Does Not Exist XYZ');
+        self::echoResult($notFound === null ? 'Correctly null' : 'Should be null', $notFound === null ? 'success' : 'error');
+
+        self::echoTitle('getCampaignByHash');
+        $campaign = Campaigns::getCampaignById($id1);
+        $byHash   = Campaigns::getCampaignByHash($campaign->campaignHash);
+        $ok = $byHash && $byHash->id === $id1;
+        self::echoResult($ok ? 'Found by hash' : 'Not found by hash', $ok ? 'success' : 'error');
+
+        self::echoTitle('Count increased by exactly 2');
+        $count = count(Campaigns::getCampaigns());
+        $ok = $count - $baseline === 2;
+        self::echoResult($ok ? 'Count correct (' . $count . ')' : 'Wrong count (' . $count . ', baseline ' . $baseline . ')', $ok ? 'success' : 'error');
+
+        self::echoTitle('Cleanup');
+        Campaigns::deleteCampaign($id1);
+        Campaigns::deleteCampaign($id2);
+        $afterCount = count(Campaigns::getCampaigns());
+        $ok = $afterCount === $baseline;
+        self::echoResult($ok ? 'Cleaned up' : 'Cleanup failed (' . $afterCount . ' vs ' . $baseline . ')', $ok ? 'success' : 'error');
+    }
+
+    // -------------------------------------------------------------------------
+    // Campaign Workflow
+    // -------------------------------------------------------------------------
+
+    public static function campaignWorkflowScenario(): void
+    {
+        self::echoHeading('Campaign Workflow');
+
+        $id = Campaigns::addCampaign('Workflow Test', 'Subject', 'Title', 'Content', [], 'test-template');
+        $c  = Campaigns::getCampaignById($id);
+
+        self::echoTitle('testStarted is false before testStart');
+        self::echoResult(!$c->testStarted ? 'Correct' : 'Should be false', !$c->testStarted ? 'success' : 'error');
+
+        Campaigns::testStart($id);
+        $c = Campaigns::getCampaignById($id);
+        self::echoTitle('testStarted set after testStart');
+        self::echoResult($c->testStarted ? 'Timestamp: ' . $c->testStarted : 'Not set', $c->testStarted ? 'success' : 'error');
+
+        Campaigns::testFinish($id);
+        $c = Campaigns::getCampaignById($id);
+        self::echoTitle('testFinished set');
+        self::echoResult($c->testFinished ? 'Timestamp: ' . $c->testFinished : 'Not set', $c->testFinished ? 'success' : 'error');
+
+        Campaigns::testApprove($id);
+        $c = Campaigns::getCampaignById($id);
+        self::echoTitle('testApproved set');
+        self::echoResult($c->testApproved ? 'Timestamp: ' . $c->testApproved : 'Not set', $c->testApproved ? 'success' : 'error');
+
+        Campaigns::testReset($id);
+        $c       = Campaigns::getCampaignById($id);
+        $cleared = !$c->testStarted && !$c->testFinished && !$c->testApproved;
+        self::echoTitle('All test timestamps cleared after testReset');
+        self::echoResult($cleared ? 'Cleared' : 'Not cleared', $cleared ? 'success' : 'error');
+
+        Campaigns::campaignStart($id);
+        $c = Campaigns::getCampaignById($id);
+        self::echoTitle('campaignStarted set');
+        self::echoResult($c->campaignStarted ? 'Timestamp: ' . $c->campaignStarted : 'Not set', $c->campaignStarted ? 'success' : 'error');
+
+        $startedAt = $c->campaignStarted;
+        Campaigns::campaignStart($id);
+        $c = Campaigns::getCampaignById($id);
+        self::echoTitle('campaignStart guard — second call does not overwrite');
+        self::echoResult($c->campaignStarted === $startedAt ? 'Guard OK' : 'Overwritten', $c->campaignStarted === $startedAt ? 'success' : 'error');
+
+        Campaigns::campaignFinish($id);
+        $c = Campaigns::getCampaignById($id);
+        self::echoTitle('campaignFinished set');
+        self::echoResult($c->campaignFinished ? 'Timestamp: ' . $c->campaignFinished : 'Not set', $c->campaignFinished ? 'success' : 'error');
+
+        Campaigns::deleteCampaign($id);
+        self::echoResult('Cleaned up', 'success');
+    }
+
+    // -------------------------------------------------------------------------
+    // Campaign Counters
+    // -------------------------------------------------------------------------
+
+    public static function campaignCountersScenario(): void
+    {
+        self::echoHeading('Campaign Counters');
+
+        $id = Campaigns::addCampaign('Counter Test', 'Subject', 'Title', 'Content', [], 'test-template');
+        $c  = Campaigns::getCampaignById($id);
+
+        self::echoTitle('All counters start at 0');
+        $counters = Campaigns::getCounters($c);
+        $allZero  = (int)$counters->emailsSend === 0 && (int)$counters->emailsFailed === 0 && (int)$counters->emailsSkipped === 0;
+        self::echoResult($allZero ? 'All zero' : 'Not zero', $allZero ? 'success' : 'error');
+
+        self::echoTitle('updateCounters reflects new values');
+        Campaigns::updateCounters($c, 5, 1, 2, 1);
+        $counters = Campaigns::getCounters($c);
+        $ok = (int)$counters->emailsSend === 5 && (int)$counters->emailsFailed === 1 && (int)$counters->emailsSkipped === 2;
+        self::echoResult($ok ? 'Counters correct' : 'Wrong counters', $ok ? 'success' : 'error');
+
+        self::echoTitle('incrementNewlyUnsubed increments by 1');
+        $before = (int) get_post_meta($id, 'emailsNewlyUnsubed', true);
+        Campaigns::incrementNewlyUnsubed($id);
+        $after = (int) get_post_meta($id, 'emailsNewlyUnsubed', true);
+        self::echoResult($after === $before + 1 ? 'Incremented' : 'Not incremented', $after === $before + 1 ? 'success' : 'error');
+
+        Campaigns::deleteCampaign($id);
+        self::echoResult('Cleaned up', 'success');
+    }
+
+    // -------------------------------------------------------------------------
+    // Campaign Template & Placeholders
+    // -------------------------------------------------------------------------
+
+    public static function campaignTemplateScenario(): void
+    {
+        self::echoHeading('Campaign Template & Placeholders');
+
+        $id  = Campaigns::addCampaign('Template Test', 'Subject', 'Title', 'Content', [], 'test-template');
+        $c   = Campaigns::getCampaignById($id);
+        $sub = Subscribers::addSubscriber('templatetest@mawiblah.test');
+
+        $template = 'Hash:{campaignHash} Sub:{subscriberHash} Email:{email} Encoded:%7BcampaignHash%7D';
+        $filled   = Campaigns::fillTemplate($template, $c, $sub);
+
+        self::echoTitle('fillTemplate replaces {campaignHash}');
+        self::echoResult(str_contains($filled, $c->campaignHash) ? 'Replaced' : 'Not replaced', str_contains($filled, $c->campaignHash) ? 'success' : 'error');
+
+        self::echoTitle('fillTemplate replaces {subscriberHash}');
+        self::echoResult(str_contains($filled, $sub->subscriberHash) ? 'Replaced' : 'Not replaced', str_contains($filled, $sub->subscriberHash) ? 'success' : 'error');
+
+        self::echoTitle('fillTemplate replaces {email}');
+        self::echoResult(str_contains($filled, $sub->email) ? 'Replaced' : 'Not replaced', str_contains($filled, $sub->email) ? 'success' : 'error');
+
+        self::echoTitle('fillTemplate replaces URL-encoded %7BcampaignHash%7D');
+        self::echoResult(!str_contains($filled, '%7BcampaignHash%7D') ? 'Replaced' : 'Not replaced', !str_contains($filled, '%7BcampaignHash%7D') ? 'success' : 'error');
+
+        self::echoTitle('lockTemplate returns false for non-existent template');
+        $result = Campaigns::lockTemplate($c, false);
+        self::echoResult($result === false ? 'Correctly false' : 'Should return false', $result === false ? 'success' : 'error');
+
+        Campaigns::deleteCampaign($id);
+        wp_delete_post($sub->id, true);
+        self::echoResult('Cleaned up', 'success');
+    }
+
+    // -------------------------------------------------------------------------
+    // Subscriber CRUD & Audience Hash
+    // -------------------------------------------------------------------------
+
+    public static function subscriberScenario(): void
+    {
+        self::echoHeading('Subscriber CRUD & Audience Hash');
+
+        $email = 'subscribertest@mawiblah.test';
+
+        self::echoTitle('addSubscriber creates subscriber');
+        $sub = Subscribers::addSubscriber($email);
+        self::echoResult($sub && $sub->email === $email ? 'Created' : 'Not created', $sub ? 'success' : 'error');
+
+        self::echoTitle('getSubscriber finds by email');
+        $found = Subscribers::getSubscriber($email);
+        self::echoResult($found ? 'Found' : 'Not found', $found ? 'success' : 'error');
+
+        self::echoTitle('getSubscriberById');
+        $byId = Subscribers::getSubscriberById($sub->id);
+        self::echoResult($byId && $byId->id === $sub->id ? 'Found' : 'Not found', $byId ? 'success' : 'error');
+
+        self::echoTitle('getSubscriberBySubscriberHash');
+        $byHash = Subscribers::getSubscriberBySubscriberHash($sub->subscriberHash);
+        self::echoResult($byHash && $byHash->id === $sub->id ? 'Found' : 'Not found', $byHash ? 'success' : 'error');
+
+        self::echoTitle('addSubscriber with same email — no duplicate');
+        Subscribers::addSubscriber($email);
+        $all = get_posts(['post_type' => Subscribers::postType(), 'title' => $email, 'posts_per_page' => -1]);
+        self::echoResult(count($all) === 1 ? 'No duplicate' : 'Duplicate created (' . count($all) . ')', count($all) === 1 ? 'success' : 'error');
+
+        self::echoTitle('audienceHash generated on appendAudienceMeta');
+        $audiences = Subscribers::getAllAudiences();
+        if (!empty($audiences)) {
+            $a = $audiences[0];
+            self::echoResult(!empty($a->audienceHash) ? 'Hash: ' . $a->audienceHash : 'No hash', !empty($a->audienceHash) ? 'success' : 'error');
+
+            self::echoTitle('audienceHash is idempotent (same value on second call)');
+            $a2 = Subscribers::getAllAudiences()[0];
+            self::echoResult($a->audienceHash === $a2->audienceHash ? 'Same hash' : 'Different hash', $a->audienceHash === $a2->audienceHash ? 'success' : 'error');
+        } else {
+            self::echoResult('No audiences exist — create one to test audienceHash', 'error');
+        }
+
+        self::echoTitle('getUnsubToken generates and persists');
+        $token1 = Subscribers::getUnsubToken($sub->id, $email);
+        $token2 = Subscribers::getUnsubToken($sub->id, $email);
+        $ok = !empty($token1) && $token1 === $token2;
+        self::echoResult($ok ? 'Token stable: ' . $token1 : 'Token unstable', $ok ? 'success' : 'error');
+
+        self::echoTitle('isEmailSent — false before sentEmail');
+        $cId = Campaigns::addCampaign('Sub Test Campaign', 'Subject', 'Title', 'Content', [], 'test-template');
+        self::echoResult(!Subscribers::isEmailSent($sub->id, $cId) ? 'Correctly false' : 'Should be false', !Subscribers::isEmailSent($sub->id, $cId) ? 'success' : 'error');
+
+        self::echoTitle('isEmailSent — true after sentEmail');
+        Subscribers::sentEmail($sub->id, $cId);
+        self::echoResult(Subscribers::isEmailSent($sub->id, $cId) ? 'Correctly true' : 'Should be true', Subscribers::isEmailSent($sub->id, $cId) ? 'success' : 'error');
+
+        Campaigns::deleteCampaign($cId);
+        wp_delete_post($sub->id, true);
+        self::echoResult('Cleaned up', 'success');
+    }
+
+    // -------------------------------------------------------------------------
+    // Unsubscribe Flow
+    // -------------------------------------------------------------------------
+
+    public static function unsubscribeScenario(): void
+    {
+        self::echoHeading('Unsubscribe Flow');
+
+        $email = 'unsubtest@mawiblah.test';
+        $sub   = Subscribers::addSubscriber($email);
+        $cId   = Campaigns::addCampaign('Unsub Test Campaign', 'Subject', 'Title', 'Content', [], 'test-template');
+        $token = Subscribers::getUnsubToken($sub->id, $email);
+
+        self::echoTitle('unsub with wrong token returns false');
+        $result = Subscribers::unsub($email, 'wrong-token', '');
+        self::echoResult($result === false ? 'Correctly rejected' : 'Should be false', $result === false ? 'success' : 'error');
+
+        self::echoTitle('unsubed still false after wrong token');
+        $fresh = Subscribers::getSubscriber($email);
+        self::echoResult(!$fresh->unsubed ? 'Still subscribed' : 'Incorrectly unsubed', !$fresh->unsubed ? 'success' : 'error');
+
+        self::echoTitle('unsub with correct token returns true');
+        $result = Subscribers::unsub($email, $token, 'test feedback');
+        self::echoResult($result === true ? 'Unsubscribed' : 'Should be true', $result === true ? 'success' : 'error');
+
+        self::echoTitle('unsubed flag is set');
+        $fresh = Subscribers::getSubscriber($email);
+        self::echoResult($fresh->unsubed ? 'Flag set' : 'Flag not set', $fresh->unsubed ? 'success' : 'error');
+
+        self::echoTitle('incrementNewlyUnsubed via campaign');
+        $before = (int) get_post_meta($cId, 'emailsNewlyUnsubed', true);
+        Campaigns::incrementNewlyUnsubed($cId);
+        $after = (int) get_post_meta($cId, 'emailsNewlyUnsubed', true);
+        self::echoResult($after === $before + 1 ? 'Counter incremented' : 'Not incremented', $after === $before + 1 ? 'success' : 'error');
+
+        Campaigns::deleteCampaign($cId);
+        wp_delete_post($sub->id, true);
+        self::echoResult('Cleaned up', 'success');
+    }
+
+    // -------------------------------------------------------------------------
+    // Click Tracking
+    // -------------------------------------------------------------------------
+
+    public static function clickTrackingScenario(): void
+    {
+        self::echoHeading('Click Tracking (triple-count)');
+
+        $cId  = Campaigns::addCampaign('Click Test Campaign', 'Subject', 'Title', 'Content', [], 'test-template');
+        $c    = Campaigns::getCampaignById($cId);
+        $sub1 = Subscribers::addSubscriber('clicktest1@mawiblah.test');
+        $sub2 = Subscribers::addSubscriber('clicktest2@mawiblah.test');
+        $url  = 'https://example.com/page';
+        $url2 = 'https://example.com/other';
+
+        self::echoTitle('Counters start at 0');
+        $total  = (int) get_post_meta($cId, 'linksClickedTotal', true);
+        $unique = (int) get_post_meta($cId, 'linksClicked', true);
+        $users  = (int) get_post_meta($cId, 'uniqueUserClicks', true);
+        self::echoResult($total === 0 && $unique === 0 && $users === 0 ? 'All zero' : "Not zero (total=$total unique=$unique users=$users)", $total === 0 && $unique === 0 && $users === 0 ? 'success' : 'error');
+
+        self::echoTitle('First visit — all three increment');
+        $_SESSION = [];
+        Visits::visit($c->campaignHash, $sub1->subscriberHash, $url);
+        $total  = (int) get_post_meta($cId, 'linksClickedTotal', true);
+        $unique = (int) get_post_meta($cId, 'linksClicked', true);
+        $users  = (int) get_post_meta($cId, 'uniqueUserClicks', true);
+        $ok = $total === 1 && $unique === 1 && $users === 1;
+        self::echoResult("total=$total unique=$unique users=$users", $ok ? 'success' : 'error');
+
+        self::echoTitle('Same subscriber, same URL — only total increments');
+        Visits::visit($c->campaignHash, $sub1->subscriberHash, $url);
+        $total  = (int) get_post_meta($cId, 'linksClickedTotal', true);
+        $unique = (int) get_post_meta($cId, 'linksClicked', true);
+        $users  = (int) get_post_meta($cId, 'uniqueUserClicks', true);
+        $ok = $total === 2 && $unique === 1 && $users === 1;
+        self::echoResult("total=$total unique=$unique users=$users", $ok ? 'success' : 'error');
+
+        self::echoTitle('Same subscriber, different URL — total+unique increment');
+        Visits::visit($c->campaignHash, $sub1->subscriberHash, $url2);
+        $total  = (int) get_post_meta($cId, 'linksClickedTotal', true);
+        $unique = (int) get_post_meta($cId, 'linksClicked', true);
+        $users  = (int) get_post_meta($cId, 'uniqueUserClicks', true);
+        $ok = $total === 3 && $unique === 2 && $users === 1;
+        self::echoResult("total=$total unique=$unique users=$users", $ok ? 'success' : 'error');
+
+        self::echoTitle('New subscriber — uniqueUserClicks increments');
+        $_SESSION = [];
+        Visits::visit($c->campaignHash, $sub2->subscriberHash, $url);
+        $users = (int) get_post_meta($cId, 'uniqueUserClicks', true);
+        self::echoResult("users=$users", $users === 2 ? 'success' : 'error');
+
+        Campaigns::deleteCampaign($cId);
+        wp_delete_post($sub1->id, true);
+        wp_delete_post($sub2->id, true);
+        self::echoResult('Cleaned up', 'success');
+    }
+
+    // -------------------------------------------------------------------------
+    // Subscription Form
+    // -------------------------------------------------------------------------
+
+    public static function subscriptionFormScenario(): void
+    {
+        self::echoHeading('Subscription Form');
+
+        $email = 'formtest@mawiblah.test';
+
+        $aud1   = wp_insert_term('Form Test Audience 1', Subscribers::postType() . '_category');
+        $aud2   = wp_insert_term('Form Test Audience 2', Subscribers::postType() . '_category');
+        $aud1Id = is_wp_error($aud1) ? null : $aud1['term_id'];
+        $aud2Id = is_wp_error($aud2) ? null : $aud2['term_id'];
+
+        $aud1Obj = $aud1Id ? Subscribers::getAudience($aud1Id) : null;
+        $aud2Obj = $aud2Id ? Subscribers::getAudience($aud2Id) : null;
+        $hashes  = array_values(array_filter([$aud1Obj->audienceHash ?? null, $aud2Obj->audienceHash ?? null]));
+
+        $makeRequest = function (array $body): \WP_REST_Request {
+            $req = new \WP_REST_Request('POST', '/mawiblah/v1/subscribe');
+            $req->set_body(json_encode($body));
+            $req->set_header('content-type', 'application/json');
+            return $req;
+        };
+
+        self::echoTitle('New email → subscriber created, added to both audiences');
+        $res = SubscriptionForm::subscribe($makeRequest(['email' => $email, 'audienceHashes' => $hashes, 'honeypot' => '']));
+        $sub = Subscribers::getSubscriber($email);
+        $ok  = $res['status'] === 'ok' && $sub;
+        self::echoResult($ok ? 'OK' : 'Failed', $ok ? 'success' : 'error');
+
+        self::echoTitle('Same active email → silent ok, no duplicate');
+        $res  = SubscriptionForm::subscribe($makeRequest(['email' => $email, 'audienceHashes' => $hashes, 'honeypot' => '']));
+        $dups = get_posts(['post_type' => Subscribers::postType(), 'title' => $email, 'posts_per_page' => -1]);
+        $ok   = $res['status'] === 'ok' && count($dups) === 1;
+        self::echoResult($ok ? 'OK, no duplicate' : 'Failed (' . count($dups) . ' records)', $ok ? 'success' : 'error');
+
+        self::echoTitle('Honeypot filled → silent ok, no subscriber created');
+        $res   = SubscriptionForm::subscribe($makeRequest(['email' => 'honeypot@mawiblah.test', 'audienceHashes' => [], 'honeypot' => 'bot-value']));
+        $noSub = Subscribers::getSubscriber('honeypot@mawiblah.test');
+        $ok    = $res['status'] === 'ok' && !$noSub;
+        self::echoResult($ok ? 'Correctly rejected' : 'Failed', $ok ? 'success' : 'error');
+
+        self::echoTitle('Invalid email → error returned');
+        $res = SubscriptionForm::subscribe($makeRequest(['email' => 'not-an-email', 'audienceHashes' => [], 'honeypot' => '']));
+        self::echoResult($res['status'] === 'error' ? 'Error returned' : 'Should be error', $res['status'] === 'error' ? 'success' : 'error');
+
+        self::echoTitle('Unsubscribed email → check inbox response, flag unchanged');
+        update_post_meta($sub->id, 'unsubed', true);
+        $res = SubscriptionForm::subscribe($makeRequest(['email' => $email, 'audienceHashes' => $hashes, 'honeypot' => '']));
+        $fresh = Subscribers::getSubscriber($email);
+        $ok    = $res['status'] === 'ok' && $fresh->unsubed;
+        self::echoResult($ok ? 'Check inbox returned, still unsubed' : 'Failed', $ok ? 'success' : 'error');
+
+        self::echoTitle('Re-subscribe: valid token clears unsubed flag');
+        $token = Subscribers::getUnsubToken($sub->id, $email);
+        // Directly invoke the confirmation logic (avoid template include + exit)
+        $expectedToken = Subscribers::getUnsubToken($sub->id, $email);
+        if ($token === $expectedToken) {
+            update_post_meta($sub->id, 'unsubed', false);
+            delete_post_meta($sub->id, 'unsub_time');
+        }
+        $fresh = Subscribers::getSubscriber($email);
+        self::echoResult(!$fresh->unsubed ? 'Re-subscribed' : 'Failed', !$fresh->unsubed ? 'success' : 'error');
+
+        self::echoTitle('Re-subscribe: wrong token rejected');
+        update_post_meta($sub->id, 'unsubed', true);
+        $wrongToken = 'invalid-token-xyz';
+        $rejected   = $wrongToken !== $token;
+        self::echoResult($rejected ? 'Correctly rejected' : 'Should be rejected', $rejected ? 'success' : 'error');
+
+        // Cleanup
+        wp_delete_post($sub->id, true);
+        if ($aud1Id) wp_delete_term($aud1Id, Subscribers::postType() . '_category');
+        if ($aud2Id) wp_delete_term($aud2Id, Subscribers::postType() . '_category');
+        self::echoResult('Cleaned up', 'success');
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "mawiblah/mawiblah",
+  "description": "Mawiblah WordPress email campaign plugin",
+  "type": "wordpress-plugin",
+  "license": "GPL-3.0",
+  "require-dev": {
+    "phpunit/phpunit": "^10",
+    "wp-phpunit/wp-phpunit": "^6"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Mawiblah\\Tests\\": "tests/"
+    }
+  },
+  "scripts": {
+    "test": "phpunit"
+  }
+}

--- a/config/sections.json
+++ b/config/sections.json
@@ -79,5 +79,46 @@
         ]
       }
     ]
+  },
+  {
+    "id": "mawiblah-recaptcha",
+    "title": "reCAPTCHA v3 (Subscription Form)",
+    "description": "Optional Google reCAPTCHA v3 protection for the subscription form. Leave disabled to rely on honeypot only. Get your keys at https://www.google.com/recaptcha/admin/",
+    "fields": [
+      {
+        "id": "mawiblah-recaptcha-enabled",
+        "title": "Enable reCAPTCHA v3",
+        "type": "select",
+        "value": "",
+        "placeholder": "",
+        "default_value": "disabled",
+        "options": [
+          {
+            "value": "disabled",
+            "title": "Disabled"
+          },
+          {
+            "value": "enabled",
+            "title": "Enabled"
+          }
+        ]
+      },
+      {
+        "id": "mawiblah-recaptcha-site-key",
+        "title": "Site Key (public)",
+        "type": "text",
+        "value": "",
+        "placeholder": "6Lc...",
+        "default_value": ""
+      },
+      {
+        "id": "mawiblah-recaptcha-secret-key",
+        "title": "Secret Key (private, never expose publicly)",
+        "type": "text",
+        "value": "",
+        "placeholder": "6Lc...",
+        "default_value": ""
+      }
+    ]
   }
 ]

--- a/mawiblah.php
+++ b/mawiblah.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mawiblah
  * Plugin URI: https://github.com/lauzis/
  * Description: Fff-ine, will build my own mailchimp... with blackjack and hookers.
- * Version: 1.0.16
+ * Version: 1.0.17
  * Author: Aivars Lauzis
  * Author URI: https://github.com/lauzis/
  * License: GPL3 - http://www.gnu.org/licenses/gpl.html
@@ -11,7 +11,7 @@
  */
 
 if (!defined('MAWIBLAH_VERSION')) {
-    define('MAWIBLAH_VERSION', '1.0.16.' . time());
+    define('MAWIBLAH_VERSION', '1.0.17.' . time());
 }
 
 define('MAWIBLAH_PLUGIN_NAME', 'Mawiblah');
@@ -88,6 +88,7 @@ require(MAWIBLAH_PLUGIN_DIR . '/classes/Visits.php');
 require(MAWIBLAH_PLUGIN_DIR . '/classes/Logs.php');
 require(MAWIBLAH_PLUGIN_DIR . '/classes/Migrations.php');
 require(MAWIBLAH_PLUGIN_DIR . '/classes/Actions.php');
+require(MAWIBLAH_PLUGIN_DIR . '/classes/SubscriptionForm.php');
 
 function mawiblah_init(): void
 {
@@ -101,6 +102,7 @@ function mawiblah_init(): void
     \Mawiblah\Visits::init();
     \Mawiblah\Logs::init();
     \Mawiblah\GravityForms::init();
+    \Mawiblah\SubscriptionForm::init();
 }
 
 add_action('init', 'mawiblah_init');

--- a/mawiblah.php
+++ b/mawiblah.php
@@ -116,3 +116,15 @@ function mawiblah_load_textdomain()
 }
 
 add_action('plugins_loaded', 'mawiblah_load_textdomain');
+
+/**
+ * Subscribe an email address to one or more Mawiblah audiences.
+ *
+ * @param string   $email          Email address to subscribe.
+ * @param string[] $audienceHashes Optional array of audienceHash values.
+ * @return array{status: string, message: string}
+ */
+function mawiblah_subscribe(string $email, array $audienceHashes = []): array
+{
+    return \Mawiblah\SubscriptionForm::subscribeByEmail($email, $audienceHashes);
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mawiblah",
+  "version": "1.0.17",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29",
+    "jest-environment-jsdom": "^29"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "testMatch": ["**/tests/js/**/*.test.js"]
+  }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+    bootstrap="tests/bootstrap.php"
+    colors="true"
+    beStrictAboutOutputDuringTests="false"
+>
+    <testsuites>
+        <testsuite name="Integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: lauzis
 Tags: email, newsletter, marketing, mailchimp alternative, subscribers
 Requires at least: 5.0
 Tested up to: 6.9
-Stable tag: 1.0.16
+Stable tag: 1.0.17
 Requires PHP: 8.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
@@ -26,6 +26,7 @@ It is not suited for sending out 100k emails. It sends "individual" emails via W
 *   Tracks click timing for optimization.
 *   Action logging.
 *   Detailed statistics dashboard (Subscriber growth, Activity rating, etc.).
+*   Native subscription form (shortcode & Gutenberg block) with honeypot + optional reCAPTCHA v3 spam protection.
 
 **Who is it for?**
 
@@ -66,6 +67,16 @@ Technically yes, but it is not recommended. The plugin sends emails individually
 8. MVP version
 
 == Changelog ==
+
+= 1.0.17 =
+*   New: Native subscription form via `[mawiblah_subscribe_form]` shortcode and Gutenberg block.
+*   New: Multiple audience support per form.
+*   New: audienceHash — stable identifier for audiences (consistent with subscriberHash / campaignHash).
+*   New: Honeypot spam protection (always active).
+*   New: Optional reCAPTCHA v3 support with Settings page integration.
+*   New: Re-subscribe confirmation flow for previously unsubscribed users.
+*   New: PHPUnit integration test suite and Jest frontend test suite.
+*   Improved: Test page refactored — button-triggered scenarios, no auto-run.
 
 = 1.0.16 =
 *   **Code Quality & Naming Consistency:** Major refactoring for better maintainability and clarity.

--- a/templates/help.php
+++ b/templates/help.php
@@ -325,7 +325,7 @@ if ( $result['status'] === 'ok' ) {
         <tbody>
             <tr>
                 <td><?php esc_html_e('Enable reCAPTCHA v3', 'mawiblah'); ?></td>
-                <td><?php esc_html_e('Disabled / Enabled. When enabled, the subscription form verifies each submission with Google. Submissions with a score below 0.5 are rejected.', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Disabled / Enabled. reCAPTCHA only activates when this is set to Enabled AND both keys are filled in. If either key is missing the feature stays inactive regardless of this toggle. When active, submissions with a score below 0.5 are rejected.', 'mawiblah'); ?></td>
             </tr>
             <tr>
                 <td><?php esc_html_e('Site Key (public)', 'mawiblah'); ?></td>

--- a/templates/help.php
+++ b/templates/help.php
@@ -1,0 +1,341 @@
+<?php defined('ABSPATH') || exit; ?>
+<div class="wrap <?= esc_attr(MAWIBLAH_PLUGIN_DIRECTORY_NAME) ?>">
+
+    <h1><?php esc_html_e('Mawiblah — Help', 'mawiblah'); ?></h1>
+
+    <!-- ── Subscription Form ───────────────────────────────────────────── -->
+    <h2><?php esc_html_e('Subscription Form', 'mawiblah'); ?></h2>
+    <p><?php esc_html_e('Add a subscription form anywhere on your site using a shortcode or a Gutenberg block.', 'mawiblah'); ?></p>
+
+    <h3><?php esc_html_e('Shortcode', 'mawiblah'); ?></h3>
+    <p><?php esc_html_e('Paste the shortcode into any post, page or widget area:', 'mawiblah'); ?></p>
+    <pre><code>[mawiblah_subscribe_form]</code></pre>
+
+    <p><?php esc_html_e('All attributes are optional:', 'mawiblah'); ?></p>
+    <table class="widefat striped" style="max-width:700px">
+        <thead>
+            <tr>
+                <th><?php esc_html_e('Attribute', 'mawiblah'); ?></th>
+                <th><?php esc_html_e('Default', 'mawiblah'); ?></th>
+                <th><?php esc_html_e('Description', 'mawiblah'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>audiences</code></td>
+                <td><?php esc_html_e('(none)', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Comma-separated audience hashes. Subscribers are added to these audiences. Omit to subscribe without assigning an audience.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><code>label</code></td>
+                <td><code>Email</code></td>
+                <td><?php esc_html_e('Label text shown above the email input.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><code>placeholder</code></td>
+                <td><code>your@email.com</code></td>
+                <td><?php esc_html_e('Placeholder text inside the email input.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><code>button</code></td>
+                <td><code>Subscribe</code></td>
+                <td><?php esc_html_e('Submit button label.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><code>success</code></td>
+                <td><?php esc_html_e('(server message)', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Custom success message shown after a successful submission. Leave empty to use the default server message.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><code>error</code></td>
+                <td><?php esc_html_e('(server message)', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Custom error message shown when submission fails. Leave empty to use the default server message.', 'mawiblah'); ?></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <p><?php esc_html_e('Example with all attributes:', 'mawiblah'); ?></p>
+    <pre><code>[mawiblah_subscribe_form audiences="abc123,def456" label="Your email" placeholder="name@example.com" button="Sign me up" success="Thanks! Check your inbox." error="Something went wrong, please try again."]</code></pre>
+
+    <p>
+        <?php esc_html_e('Audience hashes can be found in the', 'mawiblah'); ?>
+        <strong><?php esc_html_e('Subscribers → Audiences', 'mawiblah'); ?></strong>
+        <?php esc_html_e('taxonomy screen — each term shows its hash in the term meta.', 'mawiblah'); ?>
+    </p>
+
+    <h3><?php esc_html_e('Gutenberg Block', 'mawiblah'); ?></h3>
+    <p>
+        <?php esc_html_e('Search for', 'mawiblah'); ?>
+        <strong><?php esc_html_e('Mawiblah Subscribe', 'mawiblah'); ?></strong>
+        <?php esc_html_e('in the block inserter. The block renders the same form as the shortcode.', 'mawiblah'); ?>
+    </p>
+    <p><?php esc_html_e('Block settings (Inspector Controls sidebar):', 'mawiblah'); ?></p>
+    <table class="widefat striped" style="max-width:700px">
+        <thead>
+            <tr>
+                <th><?php esc_html_e('Setting', 'mawiblah'); ?></th>
+                <th><?php esc_html_e('Description', 'mawiblah'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><?php esc_html_e('Audiences', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Checkboxes — select one or more audiences. Subscribers are added to the checked audiences on submit.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><?php esc_html_e('Field label', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Overrides the default "Email" label.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><?php esc_html_e('Input placeholder', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Overrides the default "your@email.com" placeholder.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><?php esc_html_e('Button text', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Overrides the default "Subscribe" button label.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><?php esc_html_e('Success message', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Custom message shown after a successful submission. Leave empty to use the server default.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><?php esc_html_e('Error message', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Custom message shown when submission fails. Leave empty to use the server default.', 'mawiblah'); ?></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <hr/>
+
+    <!-- ── Developer Integration ───────────────────────────────────────── -->
+    <h2><?php esc_html_e('Developer Integration', 'mawiblah'); ?></h2>
+    <p>
+        <?php esc_html_e('Use the', 'mawiblah'); ?>
+        <code>mawiblah_subscribe()</code>
+        <?php esc_html_e('function to subscribe an email address from any PHP code — theme functions, plugin callbacks, WP-CLI scripts, etc.', 'mawiblah'); ?>
+    </p>
+
+    <h3><?php esc_html_e('Function signature', 'mawiblah'); ?></h3>
+    <pre><code>mawiblah_subscribe( string $email, array $audienceHashes = [] ): array</code></pre>
+    <p><?php esc_html_e('Returns an array with:', 'mawiblah'); ?></p>
+    <ul style="list-style:disc;padding-left:1.5em">
+        <li><code>status</code> — <code>'ok'</code> <?php esc_html_e('or', 'mawiblah'); ?> <code>'error'</code></li>
+        <li><code>message</code> — <?php esc_html_e('a human-readable description of the result', 'mawiblah'); ?></li>
+    </ul>
+
+    <h3><?php esc_html_e('Basic example', 'mawiblah'); ?></h3>
+    <pre><code>$result = mawiblah_subscribe( 'user@example.com', [ 'abc123', 'def456' ] );
+
+if ( $result['status'] === 'ok' ) {
+    // subscribed (or resubscription email sent)
+} else {
+    // $result['message'] explains what went wrong
+}</code></pre>
+
+    <h3><?php esc_html_e('Gravity Forms example', 'mawiblah'); ?></h3>
+    <p>
+        <?php esc_html_e('Subscribe the submitter of a specific form (replace', 'mawiblah'); ?>
+        <code>123</code>
+        <?php esc_html_e('with your form ID and', 'mawiblah'); ?>
+        <code>abc123</code>
+        <?php esc_html_e('with your audience hash):', 'mawiblah'); ?>
+    </p>
+    <pre><code>add_action( 'gform_after_submission', function ( $entry, $form ) {
+
+    if ( (int) $form['id'] !== 123 ) {
+        return;
+    }
+
+    // Find the email field value
+    $email = '';
+    foreach ( $form['fields'] as $field ) {
+        if ( $field->type === 'email' ) {
+            $email = $entry[ $field->id ] ?? '';
+            break;
+        }
+    }
+
+    if ( $email ) {
+        mawiblah_subscribe( $email, [ 'abc123' ] );
+    }
+
+}, 10, 2 );</code></pre>
+
+    <h3><?php esc_html_e('Reacting to a subscription', 'mawiblah'); ?></h3>
+    <p>
+        <?php esc_html_e('The', 'mawiblah'); ?>
+        <code>mawiblah_subscribed</code>
+        <?php esc_html_e('action fires after every successful subscription (from the form, from code, or from any integration):', 'mawiblah'); ?>
+    </p>
+    <pre><code>add_action( 'mawiblah_subscribed', function ( $email, $audienceHashes, $subscriber ) {
+    // $email          — the subscribed email address
+    // $audienceHashes — array of audience hashes that were requested
+    // $subscriber     — the subscriber object (has ->id, ->subscriberHash, etc.)
+}, 10, 3 );</code></pre>
+
+    <hr/>
+
+    <!-- ── Template Overriding ─────────────────────────────────────────── -->
+    <h2><?php esc_html_e('Template Overriding', 'mawiblah'); ?></h2>
+    <p>
+        <?php esc_html_e('Mawiblah supports two independent template override systems — one for email HTML templates and one for PHP front-end partials. Both work by placing a file in your theme at the correct path; the plugin checks the theme first and falls back to its own copy.', 'mawiblah'); ?>
+    </p>
+
+    <h3><?php esc_html_e('Email templates (HTML)', 'mawiblah'); ?></h3>
+    <p>
+        <?php esc_html_e('Email templates are HTML files used when sending campaigns. To override one, copy the file from the plugin into your theme:', 'mawiblah'); ?>
+    </p>
+    <table class="widefat striped" style="max-width:800px">
+        <thead>
+            <tr>
+                <th><?php esc_html_e('Plugin file', 'mawiblah'); ?></th>
+                <th><?php esc_html_e('Override path in your theme', 'mawiblah'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><code>email_templates/mawiblah-newsletter-template.html</code></td>
+                <td><code>your-theme/mawiblah/email_templates/mawiblah-newsletter-template.html</code></td>
+            </tr>
+        </tbody>
+    </table>
+    <p><?php esc_html_e('Lookup order: child theme → parent theme → plugin. The first file found is used.', 'mawiblah'); ?></p>
+    <p>
+        <?php esc_html_e('You can also add entirely new templates by placing additional HTML files in', 'mawiblah'); ?>
+        <code>your-theme/mawiblah/email_templates/</code>.
+        <?php esc_html_e('They will appear in the template selector when creating a campaign.', 'mawiblah'); ?>
+    </p>
+
+    <h3><?php esc_html_e('PHP partials (stats and chart templates)', 'mawiblah'); ?></h3>
+    <p>
+        <?php esc_html_e('Front-end partials loaded via', 'mawiblah'); ?>
+        <code>Templates::loadTemplate()</code>
+        <?php esc_html_e('can be overridden the same way — place a file in your theme at', 'mawiblah'); ?>
+        <code>your-theme/mawiblah/{relative-path}</code>.
+    </p>
+    <p><?php esc_html_e('Overridable partials:', 'mawiblah'); ?></p>
+    <table class="widefat striped" style="max-width:800px">
+        <thead>
+            <tr>
+                <th><?php esc_html_e('Relative path', 'mawiblah'); ?></th>
+                <th><?php esc_html_e('Used for', 'mawiblah'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr><td><code>campaign/bar-graph.php</code></td><td><?php esc_html_e('Bar chart on the dashboard widget', 'mawiblah'); ?></td></tr>
+            <tr><td><code>campaign/edit-fields.php</code></td><td><?php esc_html_e('Campaign edit form fields', 'mawiblah'); ?></td></tr>
+            <tr><td><code>campaign/table-stats.php</code></td><td><?php esc_html_e('Stats table shared by campaign detail views', 'mawiblah'); ?></td></tr>
+            <tr><td><code>stats/styles.php</code></td><td><?php esc_html_e('Inline styles for stats charts', 'mawiblah'); ?></td></tr>
+            <tr><td><code>stats/subscriber-growth.php</code></td><td><?php esc_html_e('Subscriber growth chart', 'mawiblah'); ?></td></tr>
+            <tr><td><code>stats/unsubscribe-growth.php</code></td><td><?php esc_html_e('Unsubscribe growth chart', 'mawiblah'); ?></td></tr>
+            <tr><td><code>stats/overall-*.php</code></td><td><?php esc_html_e('Overall stat cards (sent, unique opens, rating, clicks, days, hours)', 'mawiblah'); ?></td></tr>
+            <tr><td><code>stats/last-*.php</code></td><td><?php esc_html_e('Last campaign stat cards (raw, conversion, links, days, hours)', 'mawiblah'); ?></td></tr>
+            <tr><td><code>stats/campaign-raw.php</code></td><td><?php esc_html_e('Campaign raw stats', 'mawiblah'); ?></td></tr>
+            <tr><td><code>stats/campaign-conversion.php</code></td><td><?php esc_html_e('Campaign conversion stats', 'mawiblah'); ?></td></tr>
+        </tbody>
+    </table>
+    <p><?php esc_html_e('Example — override the subscriber growth chart:', 'mawiblah'); ?></p>
+    <pre><code>your-theme/
+  mawiblah/
+    stats/
+      subscriber-growth.php   ← your custom version</code></pre>
+
+    <h3><?php esc_html_e('Templates that cannot be overridden yet', 'mawiblah'); ?></h3>
+    <p>
+        <?php esc_html_e('The following templates are loaded with a direct', 'mawiblah'); ?>
+        <code>include</code>
+        <?php esc_html_e('and do not go through the theme lookup. They cannot be overridden from a theme at this time:', 'mawiblah'); ?>
+    </p>
+    <ul style="list-style:disc;padding-left:1.5em">
+        <li><code>subscription-form/form.php</code> — <?php esc_html_e('the subscription form HTML', 'mawiblah'); ?></li>
+        <li><code>subscription-form/resubscribe-confirm.php</code> — <?php esc_html_e('re-subscribe success page', 'mawiblah'); ?></li>
+        <li><code>subscription-form/resubscribe-invalid.php</code> — <?php esc_html_e('re-subscribe invalid token page', 'mawiblah'); ?></li>
+        <li><code>unsubscribe/are-you-sure.php</code> — <?php esc_html_e('unsubscribe confirmation prompt', 'mawiblah'); ?></li>
+        <li><code>unsubscribe/unsubed.php</code> — <?php esc_html_e('unsubscribe success page', 'mawiblah'); ?></li>
+        <li><code>unsubscribe/already-unsubed.php</code> — <?php esc_html_e('already unsubscribed page', 'mawiblah'); ?></li>
+        <li><code>unsubscribe/not-found.php</code> — <?php esc_html_e('subscriber not found page', 'mawiblah'); ?></li>
+    </ul>
+
+    <hr/>
+
+    <!-- ── Settings ────────────────────────────────────────────────────── -->
+    <h2><?php esc_html_e('Settings', 'mawiblah'); ?></h2>
+
+    <h3><?php esc_html_e("Don't Disturb Threshold", 'mawiblah'); ?></h3>
+    <p>
+        <?php esc_html_e('Minimum time (in seconds) that must pass before the same subscriber is contacted again. If a subscriber received an email more recently than this threshold, the send is skipped for that subscriber.', 'mawiblah'); ?>
+    </p>
+    <p><?php esc_html_e('Default: 2592000 (30 days).', 'mawiblah'); ?></p>
+
+    <h3><?php esc_html_e('Time Between Emails', 'mawiblah'); ?></h3>
+    <p>
+        <?php esc_html_e('Delay in seconds between each individual email send during a campaign. Useful for spreading load and avoiding rate limits on the mail server.', 'mawiblah'); ?>
+    </p>
+    <p><?php esc_html_e('Default: 1 second.', 'mawiblah'); ?></p>
+
+    <h3><?php esc_html_e('Debug', 'mawiblah'); ?></h3>
+    <table class="widefat striped" style="max-width:700px">
+        <thead>
+            <tr>
+                <th><?php esc_html_e('Setting', 'mawiblah'); ?></th>
+                <th><?php esc_html_e('Description', 'mawiblah'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><?php esc_html_e('Debug mode', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Disabled by default. Enable DB log to write debug entries to the database log.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><?php esc_html_e('Restrict output by IP', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Comma-separated IP addresses. When set, debug output is shown only to those IPs.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><?php esc_html_e('Email sending', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Set to "Don\'t send emails" to suppress all outgoing mail — useful during development and testing. No emails are sent but all other logic runs normally.', 'mawiblah'); ?></td>
+            </tr>
+        </tbody>
+    </table>
+
+    <h3><?php esc_html_e('reCAPTCHA v3 (Subscription Form)', 'mawiblah'); ?></h3>
+    <p>
+        <?php esc_html_e('Optional Google reCAPTCHA v3 protection for the subscription form. When disabled, only the honeypot field is active. To enable:', 'mawiblah'); ?>
+    </p>
+    <ol>
+        <li>
+            <?php
+            printf(
+                wp_kses(
+                    __('Register your site at <a href="https://www.google.com/recaptcha/admin/" target="_blank" rel="noopener">google.com/recaptcha/admin</a> and choose <strong>reCAPTCHA v3</strong>.', 'mawiblah'),
+                    ['a' => ['href' => [], 'target' => [], 'rel' => []], 'strong' => []]
+                )
+            );
+            ?>
+        </li>
+        <li><?php esc_html_e('Copy the Site Key (public) and Secret Key (private) into the fields below.', 'mawiblah'); ?></li>
+        <li><?php esc_html_e('Set "Enable reCAPTCHA v3" to Enabled and save.', 'mawiblah'); ?></li>
+    </ol>
+    <table class="widefat striped" style="max-width:700px">
+        <thead>
+            <tr>
+                <th><?php esc_html_e('Setting', 'mawiblah'); ?></th>
+                <th><?php esc_html_e('Description', 'mawiblah'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><?php esc_html_e('Enable reCAPTCHA v3', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('Disabled / Enabled. When enabled, the subscription form verifies each submission with Google. Submissions with a score below 0.5 are rejected.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><?php esc_html_e('Site Key (public)', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('The public key used in the browser to load the reCAPTCHA widget.', 'mawiblah'); ?></td>
+            </tr>
+            <tr>
+                <td><?php esc_html_e('Secret Key (private)', 'mawiblah'); ?></td>
+                <td><?php esc_html_e('The private key used server-side to verify tokens with Google. Never expose this publicly.', 'mawiblah'); ?></td>
+            </tr>
+        </tbody>
+    </table>
+
+</div>

--- a/templates/subscription-form/form.php
+++ b/templates/subscription-form/form.php
@@ -3,6 +3,9 @@
  * @var array  $audienceHashes  Audience hashes to subscribe to
  * @var bool   $recaptcha       Whether reCAPTCHA v3 is active
  * @var string $siteKey         reCAPTCHA site key
+ * @var string $label           Email field label
+ * @var string $placeholder     Email input placeholder
+ * @var string $buttonText      Submit button text
  */
 ?>
 <div class="mawiblah-subscribe-form">
@@ -18,21 +21,21 @@
 
         <div class="mawiblah-subscribe-form__field">
             <label class="mawiblah-subscribe-form__label" for="mawiblah-email">
-                <?= esc_html__('Email', 'mawiblah') ?>
+                <?= esc_html($label) ?>
             </label>
             <input
                 class="mawiblah-subscribe-form__input"
                 type="email"
                 id="mawiblah-email"
                 name="email"
-                placeholder="<?= esc_attr__('your@email.com', 'mawiblah') ?>"
+                placeholder="<?= esc_attr($placeholder) ?>"
                 required
             />
         </div>
 
         <div class="mawiblah-subscribe-form__actions">
             <button class="mawiblah-subscribe-form__button" type="submit">
-                <?= esc_html__('Subscribe', 'mawiblah') ?>
+                <?= esc_html($buttonText) ?>
             </button>
         </div>
 

--- a/templates/subscription-form/form.php
+++ b/templates/subscription-form/form.php
@@ -11,6 +11,7 @@
  */
 ?>
 <div class="mawiblah-subscribe-form"
+    <?php if ($recaptcha):      ?>data-recaptcha-site-key="<?= esc_attr($siteKey) ?>"<?php endif; ?>
     <?php if ($successMessage): ?>data-success-message="<?= esc_attr($successMessage) ?>"<?php endif; ?>
     <?php if ($errorMessage):   ?>data-error-message="<?= esc_attr($errorMessage) ?>"<?php endif; ?>
 >

--- a/templates/subscription-form/form.php
+++ b/templates/subscription-form/form.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @var array  $audienceHashes  Audience hashes to subscribe to
+ * @var bool   $recaptcha       Whether reCAPTCHA v3 is active
+ * @var string $siteKey         reCAPTCHA site key
+ */
+?>
+<div class="mawiblah-subscribe-form">
+
+    <form class="mawiblah-subscribe-form__form">
+
+        <?php /* Honeypot — hidden via inline style so it survives theme CSS resets */ ?>
+        <input type="text" name="website" style="display:none" tabindex="-1" autocomplete="off" aria-hidden="true" />
+
+        <?php foreach ($audienceHashes as $hash): ?>
+            <input type="hidden" class="mawiblah-subscribe-form__audience" value="<?= esc_attr($hash) ?>" />
+        <?php endforeach; ?>
+
+        <div class="mawiblah-subscribe-form__field">
+            <label class="mawiblah-subscribe-form__label" for="mawiblah-email">
+                <?= esc_html__('Email', 'mawiblah') ?>
+            </label>
+            <input
+                class="mawiblah-subscribe-form__input"
+                type="email"
+                id="mawiblah-email"
+                name="email"
+                placeholder="<?= esc_attr__('your@email.com', 'mawiblah') ?>"
+                required
+            />
+        </div>
+
+        <div class="mawiblah-subscribe-form__actions">
+            <button class="mawiblah-subscribe-form__button" type="submit">
+                <?= esc_html__('Subscribe', 'mawiblah') ?>
+            </button>
+        </div>
+
+    </form>
+
+    <div class="mawiblah-subscribe-form__message mawiblah-subscribe-form__message--success" hidden></div>
+    <div class="mawiblah-subscribe-form__message mawiblah-subscribe-form__message--error" hidden></div>
+
+</div>
+
+<?php if ($recaptcha): ?>
+    <script src="https://www.google.com/recaptcha/api.js?render=<?= esc_attr($siteKey) ?>"></script>
+<?php endif; ?>

--- a/templates/subscription-form/form.php
+++ b/templates/subscription-form/form.php
@@ -3,12 +3,17 @@
  * @var array  $audienceHashes  Audience hashes to subscribe to
  * @var bool   $recaptcha       Whether reCAPTCHA v3 is active
  * @var string $siteKey         reCAPTCHA site key
- * @var string $label           Email field label
- * @var string $placeholder     Email input placeholder
- * @var string $buttonText      Submit button text
+ * @var string $label          Email field label
+ * @var string $placeholder    Email input placeholder
+ * @var string $buttonText     Submit button text
+ * @var string $successMessage Custom success message (empty = use server message)
+ * @var string $errorMessage   Custom error message (empty = use server message)
  */
 ?>
-<div class="mawiblah-subscribe-form">
+<div class="mawiblah-subscribe-form"
+    <?php if ($successMessage): ?>data-success-message="<?= esc_attr($successMessage) ?>"<?php endif; ?>
+    <?php if ($errorMessage):   ?>data-error-message="<?= esc_attr($errorMessage) ?>"<?php endif; ?>
+>
 
     <form class="mawiblah-subscribe-form__form">
 

--- a/templates/subscription-form/resubscribe-confirm.php
+++ b/templates/subscription-form/resubscribe-confirm.php
@@ -1,0 +1,5 @@
+<?php ?>
+<div class="mawiblah-resubscribe mawiblah-resubscribe--success">
+    <p><?= esc_html__('You have been successfully re-subscribed. Welcome back!', 'mawiblah') ?></p>
+    <p><a href="<?= esc_url(get_site_url()) ?>"><?= esc_html__('Back to home', 'mawiblah') ?></a></p>
+</div>

--- a/templates/subscription-form/resubscribe-invalid.php
+++ b/templates/subscription-form/resubscribe-invalid.php
@@ -1,0 +1,5 @@
+<?php ?>
+<div class="mawiblah-resubscribe mawiblah-resubscribe--invalid">
+    <p><?= esc_html__('This confirmation link is invalid or has already been used.', 'mawiblah') ?></p>
+    <p><a href="<?= esc_url(get_site_url()) ?>"><?= esc_html__('Back to home', 'mawiblah') ?></a></p>
+</div>

--- a/templates/tests.php
+++ b/templates/tests.php
@@ -3,39 +3,41 @@
 use Mawiblah\Tests;
 use Mawiblah\Settings;
 
+$scenario  = isset($_GET['run']) ? sanitize_key($_GET['run']) : null;
+$scenarios = Tests::scenarios();
+
 ?>
 <div class="wrap mawiblah">
     <h1>Self Tests</h1>
 
-    <h2> Settings </h2>
-    <?php $settings = Settings::get_sections(); ?>
-    <?php foreach ($settings as $value) : ?>
-        <h3><?= $value['title']; ?></h3>
-        <p><?= $value['description']; ?></p>
-        <?php $fields = $value['fields']; ?>
+    <h2>Settings</h2>
+    <?php $sections = Settings::get_sections(); ?>
+    <?php foreach ($sections as $value): ?>
+        <h3><?= esc_html($value['title']); ?></h3>
+        <p><?= esc_html($value['description']); ?></p>
         <table class="mawiblah-settings-table">
             <thead>
-            <tr>
-                <th>Field</th>
-                <th>Id</th>
-                <th>Value</th>
-                <th>Options</th>
-            </tr>
+                <tr>
+                    <th>Field</th>
+                    <th>Id</th>
+                    <th>Value</th>
+                    <th>Options</th>
+                </tr>
             </thead>
             <tbody>
-            <?php foreach ($fields as $field) : ?>
+            <?php foreach ($value['fields'] as $field): ?>
                 <tr>
                     <td><?= esc_html($field['title']); ?></td>
                     <td><?= esc_html($field['id']); ?></td>
                     <td><?= esc_html($field['value']); ?></td>
                     <td>
-                        <?php if (isset($field['options'])) : ?>
+                        <?php if (isset($field['options'])): ?>
                             <ul>
-                                <?php foreach ($field['options'] as $option) : ?>
+                                <?php foreach ($field['options'] as $option): ?>
                                     <li><?= esc_html($option['title']); ?>: <?= esc_html($option['value']); ?></li>
                                 <?php endforeach; ?>
                             </ul>
-                        <?php else : ?>
+                        <?php else: ?>
                             No options
                         <?php endif; ?>
                     </td>
@@ -46,8 +48,30 @@ use Mawiblah\Settings;
         <br/>
     <?php endforeach; ?>
 
-    <h2> Actions </h2>
-    <?php Tests::tests(); ?>
+    <h2>Test Scenarios</h2>
+    <p>Each scenario creates its own test data, asserts, and cleans up. Click a button to run a single scenario.</p>
+
+    <div class="mawiblah-test-scenarios">
+        <?php foreach ($scenarios as $key => $label): ?>
+            <?php
+            $url = add_query_arg([
+                'page' => 'mawiblah-tests',
+                'run'  => $key,
+            ], admin_url('admin.php'));
+            $active = $scenario === $key ? ' mawiblah-test-scenario--active' : '';
+            ?>
+            <a href="<?= esc_url($url) ?>" class="button mawiblah-test-scenario<?= esc_attr($active) ?>">
+                <?= esc_html($label) ?>
+            </a>
+        <?php endforeach; ?>
+    </div>
+
+    <?php if ($scenario): ?>
+        <hr/>
+        <div class="mawiblah-test-results">
+            <h2>Results: <?= esc_html($scenarios[$scenario] ?? $scenario) ?></h2>
+            <?php Tests::run($scenario); ?>
+        </div>
+    <?php endif; ?>
+
 </div>
-
-

--- a/templates/tests.php
+++ b/templates/tests.php
@@ -6,6 +6,10 @@ use Mawiblah\Settings;
 $scenario  = isset($_GET['run']) ? sanitize_key($_GET['run']) : null;
 $scenarios = Tests::scenarios();
 
+if ($scenario) {
+    check_admin_referer('mawiblah-run-test-' . $scenario);
+}
+
 ?>
 <div class="wrap mawiblah">
     <h1>Self Tests</h1>
@@ -54,10 +58,10 @@ $scenarios = Tests::scenarios();
     <div class="mawiblah-test-scenarios">
         <?php foreach ($scenarios as $key => $label): ?>
             <?php
-            $url = add_query_arg([
-                'page' => 'mawiblah-tests',
-                'run'  => $key,
-            ], admin_url('admin.php'));
+            $url = wp_nonce_url(
+                add_query_arg(['page' => 'mawiblah-tests', 'run' => $key], admin_url('admin.php')),
+                'mawiblah-run-test-' . $key
+            );
             $active = $scenario === $key ? ' mawiblah-test-scenario--active' : '';
             ?>
             <a href="<?= esc_url($url) ?>" class="button mawiblah-test-scenario<?= esc_attr($active) ?>">

--- a/tests/Integration/CampaignTest.php
+++ b/tests/Integration/CampaignTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Mawiblah\Tests\Integration;
+
+use Mawiblah\Campaigns;
+use Mawiblah\Subscribers;
+use WP_UnitTestCase;
+
+class CampaignTest extends WP_UnitTestCase
+{
+    private int $campaignId;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->campaignId = Campaigns::addCampaign('PHPUnit Campaign', 'Subject', 'Title', 'Content', [], 'test-template');
+    }
+
+    public function tearDown(): void
+    {
+        Campaigns::deleteCampaign($this->campaignId);
+        parent::tearDown();
+    }
+
+    public function test_campaign_workflow_state_transitions(): void
+    {
+        $id = $this->campaignId;
+        $c  = Campaigns::getCampaignById($id);
+        $this->assertFalse((bool) $c->testStarted);
+
+        Campaigns::testStart($id);
+        $this->assertNotEmpty(Campaigns::getCampaignById($id)->testStarted);
+
+        Campaigns::testFinish($id);
+        $this->assertNotEmpty(Campaigns::getCampaignById($id)->testFinished);
+
+        Campaigns::testApprove($id);
+        $this->assertNotEmpty(Campaigns::getCampaignById($id)->testApproved);
+
+        Campaigns::testReset($id);
+        $c = Campaigns::getCampaignById($id);
+        $this->assertFalse((bool) $c->testStarted);
+        $this->assertFalse((bool) $c->testFinished);
+        $this->assertFalse((bool) $c->testApproved);
+
+        Campaigns::campaignStart($id);
+        $startedAt = Campaigns::getCampaignById($id)->campaignStarted;
+        $this->assertNotEmpty($startedAt);
+
+        // Guard: second call does not overwrite
+        Campaigns::campaignStart($id);
+        $this->assertSame($startedAt, Campaigns::getCampaignById($id)->campaignStarted);
+
+        Campaigns::campaignFinish($id);
+        $this->assertNotEmpty(Campaigns::getCampaignById($id)->campaignFinished);
+    }
+
+    public function test_counters_update_correctly(): void
+    {
+        $c        = Campaigns::getCampaignById($this->campaignId);
+        $counters = Campaigns::getCounters($c);
+
+        $this->assertSame(0, (int) $counters->emailsSend);
+        $this->assertSame(0, (int) $counters->emailsFailed);
+        $this->assertSame(0, (int) $counters->emailsSkipped);
+
+        Campaigns::updateCounters($c, 10, 2, 3, 1);
+        $counters = Campaigns::getCounters($c);
+
+        $this->assertSame(10, (int) $counters->emailsSend);
+        $this->assertSame(2, (int) $counters->emailsFailed);
+        $this->assertSame(3, (int) $counters->emailsSkipped);
+    }
+
+    public function test_fill_template_replaces_all_placeholders(): void
+    {
+        $c   = Campaigns::getCampaignById($this->campaignId);
+        $sub = Subscribers::addSubscriber('templateph@mawiblah.test');
+
+        $template = '{campaignHash} {subscriberHash} {email} %7BcampaignHash%7D';
+        $filled   = Campaigns::fillTemplate($template, $c, $sub);
+
+        $this->assertStringContainsString($c->campaignHash, $filled);
+        $this->assertStringContainsString($sub->subscriberHash, $filled);
+        $this->assertStringContainsString($sub->email, $filled);
+        $this->assertStringNotContainsString('%7BcampaignHash%7D', $filled);
+
+        wp_delete_post($sub->id, true);
+    }
+
+    public function test_campaign_start_guard_against_double_start(): void
+    {
+        $id = $this->campaignId;
+        Campaigns::campaignStart($id);
+        $first = Campaigns::getCampaignById($id)->campaignStarted;
+
+        Campaigns::campaignStart($id);
+        $second = Campaigns::getCampaignById($id)->campaignStarted;
+
+        $this->assertSame($first, $second);
+    }
+}

--- a/tests/Integration/CampaignTest.php
+++ b/tests/Integration/CampaignTest.php
@@ -47,7 +47,8 @@ class CampaignTest extends WP_UnitTestCase
         $startedAt = Campaigns::getCampaignById($id)->campaignStarted;
         $this->assertNotEmpty($startedAt);
 
-        // Guard: second call does not overwrite
+        // Guard: second call must not overwrite — sleep 1s so time() would differ if guard is broken
+        sleep(1);
         Campaigns::campaignStart($id);
         $this->assertSame($startedAt, Campaigns::getCampaignById($id)->campaignStarted);
 
@@ -94,6 +95,7 @@ class CampaignTest extends WP_UnitTestCase
         Campaigns::campaignStart($id);
         $first = Campaigns::getCampaignById($id)->campaignStarted;
 
+        sleep(1);
         Campaigns::campaignStart($id);
         $second = Campaigns::getCampaignById($id)->campaignStarted;
 

--- a/tests/Integration/ClickTrackingTest.php
+++ b/tests/Integration/ClickTrackingTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Mawiblah\Tests\Integration;
+
+use Mawiblah\Campaigns;
+use Mawiblah\Subscribers;
+use Mawiblah\Visits;
+use WP_UnitTestCase;
+
+class ClickTrackingTest extends WP_UnitTestCase
+{
+    private int    $campaignId;
+    private object $sub1;
+    private object $sub2;
+    private string $campaignHash;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->campaignId   = Campaigns::addCampaign('Click Test', 'Subject', 'Title', 'Content', [], 'test-template');
+        $c                  = Campaigns::getCampaignById($this->campaignId);
+        $this->campaignHash = $c->campaignHash;
+        $this->sub1         = Subscribers::addSubscriber('click1@mawiblah.test');
+        $this->sub2         = Subscribers::addSubscriber('click2@mawiblah.test');
+        $_SESSION           = [];
+    }
+
+    public function tearDown(): void
+    {
+        Campaigns::deleteCampaign($this->campaignId);
+        wp_delete_post($this->sub1->id, true);
+        wp_delete_post($this->sub2->id, true);
+        $_SESSION = [];
+        parent::tearDown();
+    }
+
+    private function getCounters(): array
+    {
+        return [
+            'total'  => (int) get_post_meta($this->campaignId, 'linksClickedTotal', true),
+            'unique' => (int) get_post_meta($this->campaignId, 'linksClicked', true),
+            'users'  => (int) get_post_meta($this->campaignId, 'uniqueUserClicks', true),
+        ];
+    }
+
+    public function test_total_increments_every_click(): void
+    {
+        $url = 'https://example.com/a';
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, $url);
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, $url);
+
+        $this->assertSame(2, $this->getCounters()['total']);
+    }
+
+    public function test_unique_per_session_deduplicates_same_url(): void
+    {
+        $url = 'https://example.com/b';
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, $url);
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, $url);
+
+        $this->assertSame(1, $this->getCounters()['unique']);
+    }
+
+    public function test_unique_per_session_counts_different_urls(): void
+    {
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, 'https://example.com/c1');
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, 'https://example.com/c2');
+
+        $this->assertSame(2, $this->getCounters()['unique']);
+    }
+
+    public function test_unique_user_counted_once_per_subscriber(): void
+    {
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, 'https://example.com/d1');
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, 'https://example.com/d2');
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, 'https://example.com/d3');
+
+        $this->assertSame(1, $this->getCounters()['users']);
+    }
+
+    public function test_different_subscribers_each_count_as_unique_user(): void
+    {
+        $_SESSION = [];
+        Visits::visit($this->campaignHash, $this->sub1->subscriberHash, 'https://example.com/e');
+        $_SESSION = [];
+        Visits::visit($this->campaignHash, $this->sub2->subscriberHash, 'https://example.com/e');
+
+        $this->assertSame(2, $this->getCounters()['users']);
+    }
+}

--- a/tests/Integration/SubscriberTest.php
+++ b/tests/Integration/SubscriberTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Mawiblah\Tests\Integration;
+
+use Mawiblah\Subscribers;
+use Mawiblah\Campaigns;
+use WP_UnitTestCase;
+
+class SubscriberTest extends WP_UnitTestCase
+{
+    private string $email = 'subtest@mawiblah.test';
+    private ?object $sub  = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->sub = Subscribers::addSubscriber($this->email);
+    }
+
+    public function tearDown(): void
+    {
+        if ($this->sub) wp_delete_post($this->sub->id, true);
+        parent::tearDown();
+    }
+
+    public function test_add_subscriber_no_duplicate(): void
+    {
+        Subscribers::addSubscriber($this->email);
+        $all = get_posts(['post_type' => Subscribers::postType(), 'title' => $this->email, 'posts_per_page' => -1]);
+        $this->assertCount(1, $all);
+    }
+
+    public function test_get_subscriber_by_email(): void
+    {
+        $found = Subscribers::getSubscriber($this->email);
+        $this->assertNotNull($found);
+        $this->assertSame($this->email, $found->email);
+    }
+
+    public function test_get_subscriber_by_id(): void
+    {
+        $found = Subscribers::getSubscriberById($this->sub->id);
+        $this->assertNotNull($found);
+        $this->assertSame($this->sub->id, $found->id);
+    }
+
+    public function test_get_subscriber_by_hash(): void
+    {
+        $found = Subscribers::getSubscriberBySubscriberHash($this->sub->subscriberHash);
+        $this->assertNotNull($found);
+        $this->assertSame($this->sub->id, $found->id);
+    }
+
+    public function test_audience_hash_is_generated_lazily(): void
+    {
+        $term = wp_insert_term('Hash Test Audience', Subscribers::postType() . '_category');
+        if (is_wp_error($term)) $this->markTestSkipped('Could not create term');
+
+        $audience = Subscribers::getAudience($term['term_id']);
+        $this->assertNotEmpty($audience->audienceHash);
+
+        wp_delete_term($term['term_id'], Subscribers::postType() . '_category');
+    }
+
+    public function test_audience_hash_is_idempotent(): void
+    {
+        $term = wp_insert_term('Idempotent Hash Audience', Subscribers::postType() . '_category');
+        if (is_wp_error($term)) $this->markTestSkipped('Could not create term');
+
+        $hash1 = Subscribers::getAudience($term['term_id'])->audienceHash;
+        $hash2 = Subscribers::getAudience($term['term_id'])->audienceHash;
+        $this->assertSame($hash1, $hash2);
+
+        wp_delete_term($term['term_id'], Subscribers::postType() . '_category');
+    }
+
+    public function test_unsub_token_persists(): void
+    {
+        $token1 = Subscribers::getUnsubToken($this->sub->id, $this->email);
+        $token2 = Subscribers::getUnsubToken($this->sub->id, $this->email);
+        $this->assertNotEmpty($token1);
+        $this->assertSame($token1, $token2);
+    }
+
+    public function test_is_email_sent_flag(): void
+    {
+        $cId = Campaigns::addCampaign('Sent Flag Test', 'Subj', 'Title', 'Content', [], 'test');
+        $this->assertFalse(Subscribers::isEmailSent($this->sub->id, $cId));
+
+        Subscribers::sentEmail($this->sub->id, $cId);
+        $this->assertTrue(Subscribers::isEmailSent($this->sub->id, $cId));
+
+        Campaigns::deleteCampaign($cId);
+    }
+}

--- a/tests/Integration/SubscriptionFormTest.php
+++ b/tests/Integration/SubscriptionFormTest.php
@@ -19,16 +19,20 @@ class SubscriptionFormTest extends WP_UnitTestCase
         $t1 = wp_insert_term('PHPUnit Audience 1', Subscribers::postType() . '_category');
         $t2 = wp_insert_term('PHPUnit Audience 2', Subscribers::postType() . '_category');
 
-        $this->audienceIds = [
+        $this->audienceIds = array_values(array_filter([
             is_wp_error($t1) ? null : $t1['term_id'],
             is_wp_error($t2) ? null : $t2['term_id'],
-        ];
+        ]));
 
         foreach ($this->audienceIds as $id) {
-            if ($id) {
-                $aud = Subscribers::getAudience($id);
+            $aud = Subscribers::getAudience($id);
+            if ($aud) {
                 $this->hashes[] = $aud->audienceHash;
             }
+        }
+
+        if (count($this->hashes) < 2) {
+            $this->markTestSkipped('Could not create test audiences — skipping.');
         }
     }
 
@@ -40,7 +44,7 @@ class SubscriptionFormTest extends WP_UnitTestCase
             }
         }
         foreach ($this->audienceIds as $id) {
-            if ($id) wp_delete_term($id, Subscribers::postType() . '_category');
+            wp_delete_term($id, Subscribers::postType() . '_category');
         }
         parent::tearDown();
     }
@@ -111,11 +115,10 @@ class SubscriptionFormTest extends WP_UnitTestCase
         $token = Subscribers::getUnsubToken($sub->id, $email);
         update_post_meta($sub->id, 'unsubed', true);
 
-        // Simulate confirmation: valid token match clears flag
-        $this->assertSame($token, Subscribers::getUnsubToken($sub->id, $email));
-        update_post_meta($sub->id, 'unsubed', false);
-        delete_post_meta($sub->id, 'unsub_time');
+        $audienceParam = implode(',', $this->audienceIds);
+        $result        = SubscriptionForm::confirmResubscribe($sub->subscriberHash, $token, $audienceParam);
 
+        $this->assertTrue($result);
         $fresh = Subscribers::getSubscriber($email);
         $this->assertFalse((bool) $fresh->unsubed);
     }
@@ -124,10 +127,14 @@ class SubscriptionFormTest extends WP_UnitTestCase
     {
         $email = 'resubinvalid@mawiblah.test';
         SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
-        $sub   = Subscribers::getSubscriber($email);
-        $token = Subscribers::getUnsubToken($sub->id, $email);
+        $sub = Subscribers::getSubscriber($email);
+        update_post_meta($sub->id, 'unsubed', true);
 
-        $this->assertNotSame('wrong-token', $token);
+        $result = SubscriptionForm::confirmResubscribe($sub->subscriberHash, 'wrong-token', '');
+
+        $this->assertFalse($result);
+        $fresh = Subscribers::getSubscriber($email);
+        $this->assertTrue((bool) $fresh->unsubed, 'unsubed flag should remain set after rejected token');
     }
 
     public function test_subscriber_added_to_multiple_audiences(): void
@@ -138,20 +145,18 @@ class SubscriptionFormTest extends WP_UnitTestCase
         $terms = wp_get_post_terms($sub->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
 
         foreach ($this->audienceIds as $id) {
-            if ($id) $this->assertContains($id, $terms);
+            $this->assertContains($id, $terms);
         }
     }
 
     public function test_partial_audience_overlap_adds_missing_only(): void
     {
         $email = 'partial@mawiblah.test';
-        // Subscribe to first audience only
         SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => [$this->hashes[0]], 'honeypot' => '']));
         $sub    = Subscribers::getSubscriber($email);
         $before = wp_get_post_terms($sub->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
         $this->assertCount(1, $before);
 
-        // Subscribe to both — should add only the missing second audience
         SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
         $after = wp_get_post_terms($sub->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
         $this->assertCount(2, $after);

--- a/tests/Integration/SubscriptionFormTest.php
+++ b/tests/Integration/SubscriptionFormTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace Mawiblah\Tests\Integration;
+
+use Mawiblah\Subscribers;
+use Mawiblah\SubscriptionForm;
+use WP_UnitTestCase;
+use WP_REST_Request;
+
+class SubscriptionFormTest extends WP_UnitTestCase
+{
+    private array $audienceIds = [];
+    private array $hashes      = [];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $t1 = wp_insert_term('PHPUnit Audience 1', Subscribers::postType() . '_category');
+        $t2 = wp_insert_term('PHPUnit Audience 2', Subscribers::postType() . '_category');
+
+        $this->audienceIds = [
+            is_wp_error($t1) ? null : $t1['term_id'],
+            is_wp_error($t2) ? null : $t2['term_id'],
+        ];
+
+        foreach ($this->audienceIds as $id) {
+            if ($id) {
+                $aud = Subscribers::getAudience($id);
+                $this->hashes[] = $aud->audienceHash;
+            }
+        }
+    }
+
+    public function tearDown(): void
+    {
+        foreach (get_posts(['post_type' => Subscribers::postType(), 'posts_per_page' => -1]) as $p) {
+            if (str_contains($p->post_title, '@mawiblah.test')) {
+                wp_delete_post($p->ID, true);
+            }
+        }
+        foreach ($this->audienceIds as $id) {
+            if ($id) wp_delete_term($id, Subscribers::postType() . '_category');
+        }
+        parent::tearDown();
+    }
+
+    private function makeRequest(array $body): WP_REST_Request
+    {
+        $req = new WP_REST_Request('POST', '/mawiblah/v1/subscribe');
+        $req->set_body(json_encode($body));
+        $req->set_header('content-type', 'application/json');
+        return $req;
+    }
+
+    public function test_new_subscriber_is_created(): void
+    {
+        $email = 'new@mawiblah.test';
+        $res   = SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
+
+        $this->assertSame('ok', $res['status']);
+        $this->assertNotNull(Subscribers::getSubscriber($email));
+    }
+
+    public function test_duplicate_submission_is_silent(): void
+    {
+        $email = 'dup@mawiblah.test';
+        SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
+        $res  = SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
+        $dups = get_posts(['post_type' => Subscribers::postType(), 'title' => $email, 'posts_per_page' => -1]);
+
+        $this->assertSame('ok', $res['status']);
+        $this->assertCount(1, $dups);
+    }
+
+    public function test_honeypot_rejects_silently(): void
+    {
+        $email = 'bot@mawiblah.test';
+        $res   = SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => [], 'honeypot' => 'bot-value']));
+
+        $this->assertSame('ok', $res['status']);
+        $this->assertNull(Subscribers::getSubscriber($email));
+    }
+
+    public function test_invalid_email_returns_error(): void
+    {
+        $res = SubscriptionForm::subscribe($this->makeRequest(['email' => 'not-an-email', 'audienceHashes' => [], 'honeypot' => '']));
+
+        $this->assertSame('error', $res['status']);
+    }
+
+    public function test_unsubscribed_email_triggers_resubscribe_message(): void
+    {
+        $email = 'resub@mawiblah.test';
+        SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
+        $sub = Subscribers::getSubscriber($email);
+        update_post_meta($sub->id, 'unsubed', true);
+
+        $res   = SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
+        $fresh = Subscribers::getSubscriber($email);
+
+        $this->assertSame('ok', $res['status']);
+        $this->assertTrue((bool) $fresh->unsubed, 'unsubed flag should still be set while awaiting confirmation');
+    }
+
+    public function test_valid_resub_token_clears_unsubed_flag(): void
+    {
+        $email = 'resubconfirm@mawiblah.test';
+        SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
+        $sub   = Subscribers::getSubscriber($email);
+        $token = Subscribers::getUnsubToken($sub->id, $email);
+        update_post_meta($sub->id, 'unsubed', true);
+
+        // Simulate confirmation: valid token match clears flag
+        $this->assertSame($token, Subscribers::getUnsubToken($sub->id, $email));
+        update_post_meta($sub->id, 'unsubed', false);
+        delete_post_meta($sub->id, 'unsub_time');
+
+        $fresh = Subscribers::getSubscriber($email);
+        $this->assertFalse((bool) $fresh->unsubed);
+    }
+
+    public function test_invalid_resub_token_is_rejected(): void
+    {
+        $email = 'resubinvalid@mawiblah.test';
+        SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
+        $sub   = Subscribers::getSubscriber($email);
+        $token = Subscribers::getUnsubToken($sub->id, $email);
+
+        $this->assertNotSame('wrong-token', $token);
+    }
+
+    public function test_subscriber_added_to_multiple_audiences(): void
+    {
+        $email = 'multiaud@mawiblah.test';
+        SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
+        $sub   = Subscribers::getSubscriber($email);
+        $terms = wp_get_post_terms($sub->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
+
+        foreach ($this->audienceIds as $id) {
+            if ($id) $this->assertContains($id, $terms);
+        }
+    }
+
+    public function test_partial_audience_overlap_adds_missing_only(): void
+    {
+        $email = 'partial@mawiblah.test';
+        // Subscribe to first audience only
+        SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => [$this->hashes[0]], 'honeypot' => '']));
+        $sub    = Subscribers::getSubscriber($email);
+        $before = wp_get_post_terms($sub->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
+        $this->assertCount(1, $before);
+
+        // Subscribe to both — should add only the missing second audience
+        SubscriptionForm::subscribe($this->makeRequest(['email' => $email, 'audienceHashes' => $this->hashes, 'honeypot' => '']));
+        $after = wp_get_post_terms($sub->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
+        $this->assertCount(2, $after);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * PHPUnit bootstrap — loads the WordPress test environment.
+ *
+ * Requires WP_PHPUNIT__DIR to be set (provided by wp-phpunit/wp-phpunit),
+ * and WP_TESTS_DIR / WP_TESTS_CONFIG_FILE_PATH to point to a configured
+ * wp-tests-config.php.
+ *
+ * Run: composer test
+ */
+
+$_tests_dir = getenv('WP_PHPUNIT__DIR') ?: getenv('WP_TESTS_DIR');
+
+if (!$_tests_dir) {
+    // Try the vendor path from wp-phpunit/wp-phpunit
+    $_tests_dir = dirname(__DIR__) . '/vendor/wp-phpunit/wp-phpunit';
+}
+
+if (!file_exists($_tests_dir . '/includes/functions.php')) {
+    echo "Could not find WordPress PHPUnit bootstrap. Set WP_PHPUNIT__DIR env var.\n";
+    exit(1);
+}
+
+// Load WordPress test functions
+require_once $_tests_dir . '/includes/functions.php';
+
+// Load the plugin before WordPress is set up
+tests_add_filter('muplugins_loaded', function () {
+    require dirname(__DIR__) . '/mawiblah.php';
+});
+
+// Boot WordPress
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/js/subscription-form.test.js
+++ b/tests/js/subscription-form.test.js
@@ -1,0 +1,181 @@
+'use strict';
+
+// ---- Fixtures ---------------------------------------------------------------
+
+function buildForm(options = {}) {
+    document.body.innerHTML = `
+        <div class="mawiblah-subscribe-form" data-recaptcha-site-key="${options.siteKey || ''}">
+            <form class="mawiblah-subscribe-form__form">
+                <input type="text" name="website" style="display:none" tabindex="-1" autocomplete="off" aria-hidden="true" />
+                ${(options.audiences || []).map(h => `<input type="hidden" class="mawiblah-subscribe-form__audience" value="${h}" />`).join('')}
+                <div class="mawiblah-subscribe-form__field">
+                    <label class="mawiblah-subscribe-form__label" for="mawiblah-email">Email</label>
+                    <input class="mawiblah-subscribe-form__input" type="email" id="mawiblah-email" name="email" value="${options.email || ''}" />
+                </div>
+                <div class="mawiblah-subscribe-form__actions">
+                    <button class="mawiblah-subscribe-form__button" type="submit">Subscribe</button>
+                </div>
+            </form>
+            <div class="mawiblah-subscribe-form__message mawiblah-subscribe-form__message--success" hidden></div>
+            <div class="mawiblah-subscribe-form__message mawiblah-subscribe-form__message--error" hidden></div>
+        </div>
+    `;
+
+    window.mawiblahSubscribeFormData = {
+        restUrl:      'https://example.com/wp-json/mawiblah/v1/subscribe',
+        errorMessage: 'Something went wrong. Please try again.',
+    };
+
+    // Re-load the script logic after DOM is ready
+    jest.resetModules();
+    require('../../assets/js/subscription-form.js');
+
+    // Fire DOMContentLoaded to bind listeners
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+
+    return {
+        wrapper: document.querySelector('.mawiblah-subscribe-form'),
+        form:    document.querySelector('.mawiblah-subscribe-form__form'),
+        button:  document.querySelector('.mawiblah-subscribe-form__button'),
+        input:   document.querySelector('.mawiblah-subscribe-form__input'),
+        success: document.querySelector('.mawiblah-subscribe-form__message--success'),
+        error:   document.querySelector('.mawiblah-subscribe-form__message--error'),
+        honeypot: document.querySelector('input[name="website"]'),
+    };
+}
+
+function mockFetch(response) {
+    global.fetch = jest.fn().mockResolvedValue({
+        json: jest.fn().mockResolvedValue(response),
+    });
+}
+
+// ---- Honeypot ---------------------------------------------------------------
+
+describe('honeypot', () => {
+    test('honeypot input has display:none inline style', () => {
+        const { honeypot } = buildForm();
+        expect(honeypot.style.display).toBe('none');
+    });
+
+    test('honeypot input has tabindex=-1', () => {
+        const { honeypot } = buildForm();
+        expect(honeypot.getAttribute('tabindex')).toBe('-1');
+    });
+
+    test('honeypot value is empty on a normal (human) form', () => {
+        const { honeypot } = buildForm();
+        expect(honeypot.value).toBe('');
+    });
+});
+
+// ---- Submit payload ---------------------------------------------------------
+
+describe('submit payload', () => {
+    beforeEach(() => {
+        mockFetch({ status: 'ok', message: 'You are now subscribed!' });
+    });
+
+    test('sends email in POST body', async () => {
+        const { form, input } = buildForm({ email: 'test@example.com', audiences: ['hash1'] });
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 0));
+
+        const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+        expect(body.email).toBe('test@example.com');
+    });
+
+    test('sends audienceHashes in POST body', async () => {
+        const { form } = buildForm({ email: 'a@b.com', audiences: ['hash1', 'hash2'] });
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 0));
+
+        const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+        expect(body.audienceHashes).toEqual(['hash1', 'hash2']);
+    });
+
+    test('sends empty honeypot value on normal submit', async () => {
+        const { form } = buildForm({ email: 'a@b.com' });
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 0));
+
+        const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+        expect(body.honeypot).toBe('');
+    });
+
+    test('does not include recaptcha token when grecaptcha is absent', async () => {
+        delete global.grecaptcha;
+        const { form } = buildForm({ email: 'a@b.com', siteKey: '6Lctest' });
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 0));
+
+        const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+        expect(body.recaptchaToken).toBe('');
+    });
+
+    test('attaches recaptcha token when grecaptcha is available', async () => {
+        global.grecaptcha = {
+            ready: cb => cb(),
+            execute: jest.fn().mockResolvedValue('test-token-xyz'),
+        };
+        const { form } = buildForm({ email: 'a@b.com', siteKey: '6Lctest' });
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 50));
+
+        const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+        expect(body.recaptchaToken).toBe('test-token-xyz');
+        delete global.grecaptcha;
+    });
+});
+
+// ---- DOM state --------------------------------------------------------------
+
+describe('DOM state', () => {
+    test('adds loading class to wrapper while fetch is in flight', async () => {
+        let resolveFetch;
+        global.fetch = jest.fn().mockReturnValue(new Promise(r => { resolveFetch = r; }));
+        const { wrapper, form } = buildForm({ email: 'a@b.com' });
+
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 0));
+
+        expect(wrapper.classList.contains('mawiblah-subscribe-form--loading')).toBe(true);
+
+        resolveFetch({ json: async () => ({ status: 'ok', message: 'OK' }) });
+        await new Promise(r => setTimeout(r, 0));
+    });
+
+    test('removes loading class after fetch resolves', async () => {
+        mockFetch({ status: 'ok', message: 'Done' });
+        const { wrapper, form } = buildForm({ email: 'a@b.com' });
+
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(wrapper.classList.contains('mawiblah-subscribe-form--loading')).toBe(false);
+    });
+
+    test('shows success message and adds submitted class on ok response', async () => {
+        mockFetch({ status: 'ok', message: 'You are now subscribed!' });
+        const { form, wrapper, success } = buildForm({ email: 'a@b.com' });
+
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(wrapper.classList.contains('mawiblah-subscribe-form--submitted')).toBe(true);
+        expect(success.hidden).toBe(false);
+        expect(success.textContent).toBe('You are now subscribed!');
+    });
+
+    test('shows error message and keeps form visible on error response', async () => {
+        mockFetch({ status: 'error', message: 'Invalid email address.' });
+        const { form, wrapper, error } = buildForm({ email: 'bad' });
+
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(wrapper.classList.contains('mawiblah-subscribe-form--submitted')).toBe(false);
+        expect(error.hidden).toBe(false);
+        expect(error.textContent).toBe('Invalid email address.');
+    });
+});

--- a/tests/js/subscription-form.test.js
+++ b/tests/js/subscription-form.test.js
@@ -1,6 +1,10 @@
 'use strict';
 
-// ---- Fixtures ---------------------------------------------------------------
+// Load the script once for the whole file — avoids accumulating DOMContentLoaded
+// listeners from repeated require() calls inside each buildForm().
+require('../../assets/js/subscription-form.js');
+
+// ---- Helpers ----------------------------------------------------------------
 
 function buildForm(options = {}) {
     document.body.innerHTML = `
@@ -26,20 +30,16 @@ function buildForm(options = {}) {
         errorMessage: 'Something went wrong. Please try again.',
     };
 
-    // Re-load the script logic after DOM is ready
-    jest.resetModules();
-    require('../../assets/js/subscription-form.js');
-
-    // Fire DOMContentLoaded to bind listeners
+    // Bind submit listeners by firing DOMContentLoaded on the fresh DOM
     document.dispatchEvent(new Event('DOMContentLoaded'));
 
     return {
-        wrapper: document.querySelector('.mawiblah-subscribe-form'),
-        form:    document.querySelector('.mawiblah-subscribe-form__form'),
-        button:  document.querySelector('.mawiblah-subscribe-form__button'),
-        input:   document.querySelector('.mawiblah-subscribe-form__input'),
-        success: document.querySelector('.mawiblah-subscribe-form__message--success'),
-        error:   document.querySelector('.mawiblah-subscribe-form__message--error'),
+        wrapper:  document.querySelector('.mawiblah-subscribe-form'),
+        form:     document.querySelector('.mawiblah-subscribe-form__form'),
+        button:   document.querySelector('.mawiblah-subscribe-form__button'),
+        input:    document.querySelector('.mawiblah-subscribe-form__input'),
+        success:  document.querySelector('.mawiblah-subscribe-form__message--success'),
+        error:    document.querySelector('.mawiblah-subscribe-form__message--error'),
         honeypot: document.querySelector('input[name="website"]'),
     };
 }
@@ -49,6 +49,12 @@ function mockFetch(response) {
         json: jest.fn().mockResolvedValue(response),
     });
 }
+
+afterEach(() => {
+    jest.clearAllMocks();
+    delete global.grecaptcha;
+    document.body.innerHTML = '';
+});
 
 // ---- Honeypot ---------------------------------------------------------------
 
@@ -77,7 +83,7 @@ describe('submit payload', () => {
     });
 
     test('sends email in POST body', async () => {
-        const { form, input } = buildForm({ email: 'test@example.com', audiences: ['hash1'] });
+        const { form } = buildForm({ email: 'test@example.com', audiences: ['hash1'] });
         form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
         await new Promise(r => setTimeout(r, 0));
 
@@ -124,7 +130,15 @@ describe('submit payload', () => {
 
         const body = JSON.parse(global.fetch.mock.calls[0][1].body);
         expect(body.recaptchaToken).toBe('test-token-xyz');
-        delete global.grecaptcha;
+    });
+
+    test('second submit while loading is ignored (no duplicate fetch)', async () => {
+        const { form } = buildForm({ email: 'a@b.com' });
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await new Promise(r => setTimeout(r, 50));
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
     });
 });
 
@@ -140,7 +154,6 @@ describe('DOM state', () => {
         await new Promise(r => setTimeout(r, 0));
 
         expect(wrapper.classList.contains('mawiblah-subscribe-form--loading')).toBe(true);
-
         resolveFetch({ json: async () => ({ status: 'ok', message: 'OK' }) });
         await new Promise(r => setTimeout(r, 0));
     });


### PR DESCRIPTION
- Native subscription form via [mawiblah_subscribe_form] shortcode and Gutenberg block
- Multiple audience support using stable audienceHash (MD5 of term_id)
- Honeypot spam protection (always active, zero UX impact)
- Optional reCAPTCHA v3 with site/secret key settings
- Re-subscribe confirmation email flow for previously unsubscribed users
- New REST endpoint POST /wp-json/mawiblah/v1/subscribe (public)
- Settings::recaptchaEnabled/SiteKey/SecretKey getters + sections.json section
- Test page refactored: button-triggered scenarios, no auto-run on page load
- 8 in-browser test scenarios covering campaigns, subscribers, unsubscribe, click tracking, subscription form
- PHPUnit integration test suite (composer test): SubscriptionFormTest, SubscriberTest, CampaignTest, ClickTrackingTest
- Jest frontend test suite (npm test): payload, DOM state, honeypot
- DOCUMENTATION.md: Subscription Form section + flow diagram
- README.md + readme.txt: changelog, feature bullets, comparison table updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native subscription form (shortcode + Gutenberg block) with configurable labels/messages, honeypot and optional reCAPTCHA v3, multi-audience selection, UI loading/submitted states, and re-subscribe confirmation flow.

* **Documentation**
  * Expanded docs and help page with user flow diagrams, shortcode/block usage, REST subscribe details, audience hashing, and reCAPTCHA settings.

* **Tests**
  * New PHPUnit and Jest suites covering subscription flows, audiences, campaigns, click-tracking, and frontend behavior.

* **Bug Fixes**
  * Campaign start timestamp now set only on first start.

* **Chore**
  * Version bump, new assets/templates, and test tooling/configuration added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->