### PR TITLE
1.0.18 add unsubscribe header

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -13,13 +13,14 @@ MAWIBLAH is a WordPress plugin that provides Mailchimp-like functionality for se
 - **Init.php** - Plugin initialization
 - **Logs.php** - Action logging for debugging
 - **Renderer.php** - Template rendering
-- **RestRoutes.php** - REST API endpoints for email sending
-- **Settings.php** - Plugin settings management
-- **ShortCodes.php** - WordPress shortcode handlers
-- **Subscribers.php** - Subscriber management
-- **Templates.php** - Email template management
-- **Tests.php** - Testing functionality
-- **Unsubscribe.php** - Unsubscribe functionality
+- **RestRoutes.php** - REST API endpoint for sending individual campaign emails (`/send-email`)
+- **Settings.php** - Plugin settings management; includes `recaptchaReady()` for safe reCAPTCHA gate
+- **ShortCodes.php** - WordPress shortcode handlers including `[mawiblah_subscribe_form]`
+- **Subscribers.php** - Subscriber management, audience taxonomy, audience hash generation
+- **SubscriptionForm.php** - Subscription form rendering, REST `/subscribe` endpoint, re-subscribe flow, programmatic `subscribeByEmail()`
+- **Templates.php** - Email template management with child/parent theme override support
+- **Tests.php** - In-browser integration test scenarios (button-triggered, self-contained)
+- **Unsubscribe.php** - Unsubscribe confirmation flow + RFC 8058 one-click REST endpoint (`/unsubscribe`)
 - **Visits.php** - Click tracking for campaigns
 
 ### Admin Interface (`/admin/`)
@@ -171,53 +172,16 @@ add_action('wp_dashboard_setup', [Actions::class, 'registerDashboardWidget']);
 - Stores click timestamps for timing analysis
 - Both unique and total click counts
 
-## Recent Changes (Session 2026-01-12)
 
-1. **Repository Standards & Security**
-   - Created `readme.txt` from `README.md` for WordPress.org compliance
-   - Added `license.txt` (GPLv3)
-   - Improved security with output escaping in `add-campaign.php`
-   - Fixed `scandir()` error handling in `Templates.php`
+## Documentation Files
 
-## Recent Changes (Session 2025-11-30)
-
-1. **Enhanced Statistics Dashboard**
-   - Added Subscriber Growth and Unsubscribe Growth graphs
-   - Added Activity Rating and Overall Active Hours metrics
-   - Visualized campaign performance with bar graphs
-
-2. **Individual Campaign Statistics**
-   - Added detailed stats to campaign view (Raw, Conversion, Links, Days, Hours)
-   - Implemented `Campaigns::getStatsForCampaign()` and `Campaigns::getConversionStatsForCampaign()`
-
-3. **Refactoring**
-   - Split dashboard templates into modular components (`templates/stats/`)
-   - Improved graph rendering with `templates/campaign/bar-graph.php`
-   - Refactored `campaignId` (hash) to `campaignHash` to distinguish from post ID (`campaignPostId`)
-
-4. **Bug Fixes & Improvements**
-   - Fixed null-safety bug in `campaignStart()`
-   - Fixed variable shadowing in stats templates
-   - Internationalized "Weekdays", "Hours", "Max", "Avg" and table headers
-   - Fixed typo in `classes/Tests.php`
-   - Preserved `campaignId` in unsubscribe flow to fix `emailsNewlyUnsubed` counter
-
-## Recent Changes (Session 2025-10-24)
-
-1. **Added `getLastCampaigns()` method** in Campaigns.php
-   - Returns most recent campaigns ordered by date (DESC)
-   - Accepts optional limit parameter (default: 5)
-
-2. **Moved dashboard widget to Actions.php**
-   - Registration: `Actions::registerDashboardWidget()`
-   - Rendering: `Actions::renderDashboardWidget()`
-   - Uses new `getLastCampaigns()` method
-
-3. **Fixed campaign counter updates**
-   - Counters now properly update in database via `updateCounters()`
-   - Only updates during actual campaigns (not test mode)
-   - Proper handling of sent/failed/skipped/unsubscribed counts
-   - Excludes "already sent" from new counts (avoids double counting)
+| File | Audience | Purpose |
+|---|---|---|
+| `README.md` | GitHub / developers | Feature overview, comparison table, full changelog (`### --- X.Y.Z ---`) |
+| `readme.txt` | WordPress.org | Plugin directory listing, `Stable tag`, short changelog (`= X.Y.Z =`) |
+| `DOCUMENTATION.md` | Developers | Architecture, flow diagrams, field references, API docs, REST endpoints |
+| `AGENT.md` | AI agent (this file) | Codebase map, dev rules, documentation obligations |
+| `templates/help.php` | Site admin (in-plugin) | End-user help page: form usage, settings, template overriding, developer integration |
 
 ## Development Guidelines
 
@@ -228,12 +192,32 @@ add_action('wp_dashboard_setup', [Actions::class, 'registerDashboardWidget']);
 - Minimal comments (code should be self-explanatory)
 
 ### Making Changes
-- **Surgical modifications** - change as few lines as possible
-- **Keep Readmes Synced** - Always update both `README.md` and `readme.txt` when making documentation or version changes
+- **Surgical modifications** — change as few lines as possible
 - Only update counters during actual campaign sends (not tests)
 - Maintain backward compatibility
 - Don't break existing functionality
 - Validate changes don't affect unrelated features
+
+### Versioning & Documentation Checklist
+
+Run through this checklist whenever a version-worthy change is complete (new feature, fix, or behaviour change):
+
+1. **`mawiblah.php`** — bump `Version:` in the plugin header and `define('MAWIBLAH_VERSION', ...)`.
+2. **`README.md`** — add `### --- X.Y.Z ---` block at the top of the changelog with bullet points for every change.
+3. **`readme.txt`** — update `Stable tag: X.Y.Z` and add `= X.Y.Z =` block to the changelog.
+4. **`DOCUMENTATION.md`** — update any section that describes changed behaviour:
+   - Flow diagrams (mermaid) if a flow changed
+   - REST endpoint tables if an endpoint was added or changed
+   - Field/counter reference tables if new fields were added
+   - API function list if public methods were added or renamed
+5. **`templates/help.php`** — update the in-plugin Help page if the change affects anything an admin configures or embeds (shortcode attributes, block settings, settings fields, template overriding, developer hooks).
+
+**What belongs in each changelog:**
+- `README.md` — full human-readable description, including context ("why" not just "what")
+- `readme.txt` — concise WordPress.org-style bullets (one line per item)
+- `DOCUMENTATION.md` — no changelog; keep it current and accurate, not historical
+
+**Do not** add session-log "Recent Changes" sections to this file. The git log and changelog files are the authoritative history.
 
 ### Counter Logic Rules
 1. Never increment counters in test mode

--- a/AGENT.md
+++ b/AGENT.md
@@ -191,6 +191,10 @@ add_action('wp_dashboard_setup', [Actions::class, 'registerDashboardWidget']);
 - Static methods for utility classes
 - Minimal comments (code should be self-explanatory)
 
+### Commit Messages
+- Do **not** add `Co-Authored-By: Claude` or any AI attribution line to commit messages.
+- Claude usage may be noted in `README.md` if appropriate, but not in individual commits.
+
 ### Making Changes
 - **Surgical modifications** — change as few lines as possible
 - Only update counters during actual campaign sends (not tests)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -103,11 +103,26 @@ flowchart TD
 
 ### Unsubscribe Flow
 
-Triggered when a subscriber clicks the unsubscribe link in a campaign email. The flow is a two-step confirmation: first shows a confirmation page, then processes the actual unsubscribe after the subscriber confirms.
+Two separate entry points share the same end state: subscriber marked `unsubed`, added to the Unsubed audience, campaign counter incremented.
+
+**Entry 1 — Mail client one-click (RFC 8058)**
+
+Every campaign email includes `List-Unsubscribe` and `List-Unsubscribe-Post: List-Unsubscribe=One-Click` headers. Gmail, Apple Mail, and other RFC 8058-compliant clients use these to show a native "Unsubscribe" button that sends a `POST` directly to the endpoint — no browser, no confirmation page.
+
+**Entry 2 — Human click (link in email body)**
+
+The `[mawiblah_unsubscribe]` shortcode in the email body renders a link with `?subscriber=hash&unsubscribe=email&campaign=hash`. Clicking it opens a confirmation page in the browser.
 
 ```mermaid
 flowchart TD
-    A[Subscriber clicks unsubscribe link\n?subscriber=hash&unsubscribe=email&campaign=hash] --> B{unsubToken\nin URL?}
+    MC[Mail client sends\nPOST /wp-json/mawiblah/v1/unsubscribe\nsubscriber · token · campaign] --> V1{subscriberHash\nfound?}
+    V1 -- No --> E1[Return 404]
+    V1 -- Yes --> V2{unsubToken\nvalid?}
+    V2 -- No --> E2[Return 403]
+    V2 -- Yes --> UNS[Mark unsubed\nadd to Unsubed audience\nincrement emailsNewlyUnsubed]
+    UNS --> OK[Return 200 OK]
+
+    HL[Subscriber clicks link in email\n?subscriber=hash&unsubscribe=email] --> B{unsubToken\nin URL?}
     B -- No --> C[unsubscribe called]
     C --> D{Found in Subscribers\nor Gravity Forms?}
     D -- No --> E[Show: not-found page]
@@ -299,7 +314,8 @@ Subscribers are organized using WordPress taxonomy (`mawiblah_subscriber_categor
 - **Mailchimp Import**: Import unsubscribed users from Mailchimp
 
 ### Subscriber Features
-- Unsubscribe functionality with confirmation
+- Unsubscribe functionality with confirmation page (human click) and RFC 8058 one-click (mail client)
+- `List-Unsubscribe` + `List-Unsubscribe-Post` headers on every campaign email
 - Last interaction tracking (first and last interaction timestamps)
 - Email throttling (configurable time between emails to same subscriber)
 - Duplicate detection (case-insensitive email matching)
@@ -409,7 +425,7 @@ Block name: `mawiblah/subscription-form`. Add via the block inserter under **Wid
 
 PHP getters: `Settings::recaptchaEnabled()`, `Settings::recaptchaSiteKey()`, `Settings::recaptchaSecretKey()`
 
-### REST Endpoint
+### REST Endpoints
 
 `POST /wp-json/mawiblah/v1/subscribe` — public, no authentication required.
 
@@ -430,6 +446,20 @@ PHP getters: `Settings::recaptchaEnabled()`, `Settings::recaptchaSiteKey()`, `Se
 { "status": "error", "message": "Invalid email address." }
 { "status": "error", "message": "Verification failed. Please try again." }
 ```
+
+`GET|POST /wp-json/mawiblah/v1/unsubscribe` — public, no authentication required.
+
+| Method | Used by | Behaviour |
+|---|---|---|
+| `POST` | Mail client (RFC 8058 one-click) | Validates `subscriber` + `token` query params, immediately unsubscribes, returns `200 OK`. |
+| `GET` | Human clicking header link | Redirects to `?subscriber=...&unsubscribe=...&unsubToken=...` confirmation page. |
+
+**Query parameters (both methods):**
+- `subscriber` — `subscriberHash` of the recipient
+- `token` — `unsubToken` of the recipient
+- `campaign` — `campaignHash` of the campaign (used to increment `emailsNewlyUnsubed`)
+
+These parameters are automatically included in the `List-Unsubscribe` header attached to every campaign email.
 
 ### Audience Hash
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -447,7 +447,7 @@ PHP getters: `Settings::recaptchaEnabled()`, `Settings::recaptchaSiteKey()`, `Se
 { "status": "error", "message": "Verification failed. Please try again." }
 ```
 
-`GET|POST /wp-json/mawiblah/v1/unsubscribe` — public, no authentication required.
+`GET|POST /wp-json/mawiblah/v1/unsubscribe` — public, no authentication required. Only `GET` and `POST` are accepted; other verbs return `405`.
 
 | Method | Used by | Behaviour |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ on all possible configurations and setups.
 | **Automation**                  | ❌ Not available at current version              | ✅ Basic (welcome emails)                   | ✅ Multi-step automation               |
 | **Click Tracking**              | ✅ Basic (clicks & timing logged)                | ✅ Basic reports                             | ✅ Advanced click stats                |
 | **Open Tracking**               | ❌ No tracking at current version                | ✅                                           | ✅                                      |
-| **Unsubscribe Support**         | ✅ Simple unsubscribe                            | ✅ Compliant unsubscribe handling            | ✅                                      |
+| **Unsubscribe Support**         | ✅ RFC 8058 one-click + confirmation flow        | ✅ Compliant unsubscribe handling            | ✅                                      |
 | **Import/Export Subscribers**   | ✅ Manual + Gravity Forms                        | ✅                                           | ✅                                      |
 | **List Segmentation**           | ✅ Basic segmentation                            | ✅ Basic segmentation                        | ✅ Advanced targeting                   |
 | **Analytics & Reports**         | ✅ Basic logging                                  | ✅ Basic dashboard                           | ✅ Detailed analytics                   |
@@ -65,6 +65,11 @@ on all possible configurations and setups.
 
 
 ## Change log
+
+### --- 1.0.18 ---
+- **New:** `List-Unsubscribe` and `List-Unsubscribe-Post: List-Unsubscribe=One-Click` headers added to every campaign email — enables one-click unsubscribe in Gmail, Apple Mail, and other RFC 8058-compliant clients.
+- **New:** `GET|POST /wp-json/mawiblah/v1/unsubscribe` REST endpoint — `POST` immediately unsubscribes (RFC 8058 one-click, used by mail clients); `GET` redirects to the existing confirmation page (used when a human clicks the header link).
+- **Fixed:** `Content-Type: text/html; charset=UTF-8` header was missing from campaign emails — HTML templates now render correctly in all mail clients.
 
 ### --- 1.0.17 ---
 - **New:** Native subscription form — add a sign-up form anywhere via `[mawiblah_subscribe_form audiences="hash1,hash2"]` shortcode or Gutenberg block.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ This is a free plugin, so support is limited.
 The main idea is to create functionality that is needed for the particular project. There is no intention to make it work
 on all possible configurations and setups.
 
+## Development
+
+The initial version was built by hand. From version 1.0.9 onward, most changes have been made with the assistance of [CodeRabbit](https://coderabbit.ai) for code review and [Claude Code](https://claude.ai/code) for implementation.
+
 ## 📊 MAWIBLAH vs Mailchimp
 
 | Feature                          | MAWIBLAH                                         | Mailchimp (Free Tier)                      | Mailchimp (Essentials / Paid)          |

--- a/classes/Actions.php
+++ b/classes/Actions.php
@@ -8,11 +8,13 @@ use Mawiblah\Templates;
 class Actions
 {
 
+    /** Registers WordPress dashboard widgets via the wp_dashboard_setup action. */
     public static function init()
     {
         add_action('wp_dashboard_setup', [self::class, 'registerDashboardWidget']);
     }
 
+    /** Registers the campaign stats and activity rating widgets on the WordPress dashboard. */
     public static function registerDashboardWidget()
     {
         wp_add_dashboard_widget(
@@ -28,6 +30,7 @@ class Actions
         );
     }
 
+    /** Renders the campaign stats bar chart (sent, unique visitors, links opened) for the last 3 campaigns. */
     public static function renderDashboardWidget()
     {
         $data = Campaigns::getDataForDashBoard(3);
@@ -40,6 +43,12 @@ class Actions
         Templates::loadTemplate('campaign/bar-graph.php', $dataForDisplay);
     }
 
+    /**
+     * Renders the activity rating bar chart showing clicks-per-campaign-send-day ratio by weekday.
+     *
+     * A rating above 1 means subscribers click more on that day than campaigns are sent on it,
+     * indicating an optimal send day.
+     */
     public static function renderActivityRatingWidget()
     {
         $activeDays = Campaigns::getClickTimesByDayOfWeekForLastCampaigns(12);

--- a/classes/Campaigns.php
+++ b/classes/Campaigns.php
@@ -212,18 +212,19 @@ class Campaigns
         ];
 
         $args = [
-            'labels' => $labels,
-            'public' => false,
+            'labels'          => $labels,
+            'public'          => false,
             'publicly_queryable' => false,
-            'show_ui' => true,
-            'show_in_menu' => true,
-            'query_var' => true,
-            'rewrite' => ['slug' => 'mawiblah-campaigns'],
+            'show_ui'         => true,
+            'show_in_menu'    => true,
+            'query_var'       => true,
+            'rewrite'         => ['slug' => 'mawiblah-campaigns'],
             'capability_type' => 'post',
-            'has_archive' => false,
-            'hierarchical' => false,
-            'menu_position' => null,
-            'supports' => ['title', 'editor'],
+            'has_archive'     => false,
+            'hierarchical'    => false,
+            'menu_position'   => null,
+            'menu_icon'       => 'dashicons-megaphone',
+            'supports'        => ['title', 'editor'],
         ];
 
         register_post_type(Campaigns::postType(), $args);

--- a/classes/Campaigns.php
+++ b/classes/Campaigns.php
@@ -13,6 +13,7 @@ class Campaigns
     const STAT_LINKS_CLICKED = 'linksClicked';
 
     // exampel http://gudlenieks.test/?utm_source=email&utm_medium=email&utm_campaign=monthly-email&mawiblahId=%7BmawiblahId%7D&unsubscribe=%7Bemail%7D
+    /** Registers the campaign post type and hooks campaign meta boxes and save handlers. */
     public static function init()
     {
         self::registerPostType();
@@ -20,6 +21,7 @@ class Campaigns
         add_action('save_post', [self::class, 'saveMetaBoxData']);
     }
 
+    /** Registers the Campaign Details and Campaign Statistics meta boxes on the campaign edit screen. */
     public static function addMetaBoxes()
     {
         add_meta_box(
@@ -41,6 +43,11 @@ class Campaigns
         );
     }
 
+    /**
+     * Renders the Campaign Details meta box (audiences, template, subject).
+     *
+     * @param \WP_Post $post The campaign post being edited.
+     */
     public static function renderDetailsMetaBox($post)
     {
         $campaign = self::appendMeta($post);
@@ -48,6 +55,14 @@ class Campaigns
         \Mawiblah\Templates::loadTemplate('campaign/edit-fields.php', $data);
     }
 
+    /**
+     * Saves campaign meta box field values on post save.
+     *
+     * Validates the nonce, skips autosaves and insufficient-capability saves.
+     * Persists subject, contentTitle, template, and audiences as post meta.
+     *
+     * @param int $post_id The post ID being saved.
+     */
     public static function saveMetaBoxData($post_id)
     {
         if (!isset($_POST['mawiblah_campaign_details_nonce'])) {
@@ -86,6 +101,13 @@ class Campaigns
         }
     }
 
+    /**
+     * Renders the Campaign Statistics meta box with raw, conversion, link, day, and hour charts.
+     *
+     * Shows a placeholder message if the campaign has not yet started.
+     *
+     * @param \WP_Post $post The campaign post being viewed.
+     */
     public static function renderStatsMetaBox($post)
     {
         $campaign = self::appendMeta($post);
@@ -121,16 +143,41 @@ class Campaigns
         echo '</div>';
     }
 
+    /**
+     * Permanently deletes a campaign post.
+     *
+     * @param int $campaignPostId Campaign post ID to delete.
+     * @return \WP_Post|false|null Deleted post on success, false or null on failure.
+     */
     public static function deleteCampaign($campaignPostId)
     {
         return wp_delete_post($campaignPostId);
     }
 
+    /**
+     * Returns true if no campaign with the given title exists.
+     *
+     * @param string $title Campaign title to check.
+     * @return bool
+     */
     public static function isUnique($title): bool
     {
         return self::getCampaign($title) == null;
     }
 
+    /**
+     * Validates all required campaign fields.
+     *
+     * Checks that title, subject, audiences, and template are non-empty, that the template
+     * file exists, and that all audience IDs are valid taxonomy terms. Prints an error
+     * message and returns false on the first failure.
+     *
+     * @param string   $title     Campaign title.
+     * @param string   $subject   Email subject line.
+     * @param int[]    $audiences Array of audience term IDs.
+     * @param string   $template  Email template filename.
+     * @return bool True if valid, false otherwise.
+     */
     public static function validateCampaign(string $title, string $subject, array $audiences, string $template): bool
     {
         if (empty($title)) {
@@ -166,6 +213,12 @@ class Campaigns
         return true;
     }
 
+    /**
+     * Returns true if the named email template file exists in any template directory.
+     *
+     * @param string $emailTemplate Template filename without extension.
+     * @return bool
+     */
     public static function validateEmailTemplate(string $emailTemplate): bool
     {
         $template = Templates::getEmailTemplateByName($emailTemplate);
@@ -176,11 +229,13 @@ class Campaigns
         return false;
     }
 
+    /** Returns the custom post type slug for campaigns. */
     public static function postType()
     {
         return MAWIBLAH_POST_TYPE_PREFIX . 'campaigns';
     }
 
+    /** Registers the campaign custom post type with WordPress (admin-only, not public). */
     public static function registerPostType()
     {
 
@@ -230,6 +285,14 @@ class Campaigns
         register_post_type(Campaigns::postType(), $args);
     }
 
+    /**
+     * Attaches all campaign meta fields to a post or campaign object.
+     *
+     * Lazily generates and persists a campaignHash if one is not yet stored.
+     *
+     * @param object $post WP_Post or campaign object to decorate.
+     * @return object The same object with all campaign meta properties attached.
+     */
     public static function appendMeta($post)
     {
         $post->id = $post->ID ?? $post->id;
@@ -265,6 +328,12 @@ class Campaigns
         return $post;
     }
 
+    /**
+     * Retrieves a campaign by its WordPress post ID.
+     *
+     * @param int $id Campaign post ID.
+     * @return object|null Campaign with meta attached, or null if not found.
+     */
     public static function getCampaignById($id): object|null
     {
         $wpPost = get_post($id);
@@ -283,6 +352,12 @@ class Campaigns
         return self::appendMeta($campaign);
     }
 
+    /**
+     * Retrieves a campaign by its public campaignHash identifier.
+     *
+     * @param string $campaignHash MD5 hash stored in the campaignHash meta field.
+     * @return object|null Campaign with meta, or null if not found.
+     */
     public static function getCampaignByHash($campaignHash): object|null
     {
         $postByMeta = get_posts([
@@ -299,6 +374,12 @@ class Campaigns
         return self::appendMeta((object)$postByMeta[0]);
     }
 
+    /**
+     * Retrieves a campaign by its exact title.
+     *
+     * @param string $title Campaign title to search for.
+     * @return object|null Campaign with meta, or null if not found.
+     */
     public static function getCampaign($title): object|null
     {
         $wpQuery = new \WP_Query([
@@ -327,6 +408,11 @@ class Campaigns
         return null;
     }
 
+    /**
+     * Returns all campaigns with meta attached.
+     *
+     * @return array Array of campaign objects.
+     */
     public static function getCampaigns(): array
     {
         $wpQuery = new \WP_Query([
@@ -354,6 +440,12 @@ class Campaigns
         return $campaigns;
     }
 
+    /**
+     * Returns the most recently created campaigns, ordered newest first.
+     *
+     * @param int $limit Maximum number of campaigns to return (default 5).
+     * @return array Array of campaign objects with meta attached.
+     */
     public static function getLastCampaigns(int $limit = 5): array
     {
         $wpQuery = new \WP_Query([
@@ -383,6 +475,17 @@ class Campaigns
         return $campaigns;
     }
 
+    /**
+     * Creates a new campaign post with all associated meta fields.
+     *
+     * @param string   $title        Campaign title.
+     * @param string   $subject      Email subject line.
+     * @param string   $contentTitle Internal content title for template placeholders.
+     * @param string   $content      Campaign post content body.
+     * @param int[]    $audiences    Array of audience term IDs.
+     * @param string   $template     Email template filename.
+     * @return int New post ID.
+     */
     public static function addCampaign(string $title, string $subject, string $contentTitle, string $content, array $audiences, string $template): int
     {
 
@@ -410,6 +513,18 @@ class Campaigns
         return $post_id;
     }
 
+    /**
+     * Updates an existing campaign's post fields and meta.
+     *
+     * @param int      $campaignPostId Post ID of the campaign to update.
+     * @param string   $title          New title.
+     * @param string   $subject        New email subject.
+     * @param string   $contentTitle   New content title.
+     * @param string   $content        New post content.
+     * @param int[]    $audiences      New array of audience term IDs.
+     * @param string   $template       New email template filename.
+     * @return int Updated post ID.
+     */
     public static function updateCampaign(int $campaignPostId, string $title, string $subject, string $contentTitle, string $content, array $audiences, string $template): int
     {
         // Prepare the post data
@@ -434,6 +549,7 @@ class Campaigns
     }
 
 
+    /** @deprecated Use getCampaigns() instead. Returns all campaigns as plain associative arrays. */
     public static function getArrayOfCampaigns(): array
     {
         $args = [
@@ -460,6 +576,12 @@ class Campaigns
         return $campaigns;
     }
 
+    /**
+     * Returns campaigns matching the given title as plain associative arrays.
+     *
+     * @param string $name Campaign title to search for.
+     * @return array Array of campaign data arrays.
+     */
     public static function getArrayOfCampaignsByName(string $name): array
     {
         $args = [
@@ -486,6 +608,11 @@ class Campaigns
         return $campaigns;
     }
 
+    /**
+     * Permanently deletes all campaigns matching the given title.
+     *
+     * @param string $name Campaign title to match.
+     */
     public static function deleteCampaignByName(string $name)
     {
 
@@ -505,6 +632,16 @@ class Campaigns
         }
     }
 
+    /**
+     * Archives the campaign template snapshot and returns the processed HTML ready for sending.
+     *
+     * Sets the campaign status to 'sending-in-progress', fetches and archives the template
+     * via REST (for WPML compatibility), evaluates shortcodes, and fills static placeholders.
+     *
+     * @param object $campaign  Campaign object with meta attached.
+     * @param bool   $testMode  When true, always refreshes the archived template copy.
+     * @return string|false Processed HTML, or false if the template could not be retrieved.
+     */
     public static function lockTemplate(object $campaign, bool $testMode): string|bool
     {
 
@@ -527,6 +664,17 @@ class Campaigns
     }
 
 
+    /**
+     * Replaces per-subscriber placeholders in a template with actual values.
+     *
+     * Handles {campaignHash}, {subscriberHash}, {email} and their URL-encoded equivalents.
+     * Called once per email just before sending.
+     *
+     * @param string $template   Template HTML (typically from lockTemplate()).
+     * @param object $campaign   Campaign object.
+     * @param object $subscriber Subscriber object.
+     * @return string Personalised HTML ready to send.
+     */
     public static function fillTemplate(string $template, object $campaign, object $subscriber): string
     {
         $email = $subscriber->email;
@@ -546,6 +694,15 @@ class Campaigns
         return $templateHTML;
     }
 
+    /**
+     * Persists the four main email-send counters for a campaign.
+     *
+     * @param object $campaign       Campaign object.
+     * @param int    $emailsSent     Total successfully sent emails.
+     * @param int    $emailsFailed   Total failed sends.
+     * @param int    $emailsSkipped  Total skipped sends.
+     * @param int    $emailsUnsubed  Total sends skipped due to unsubscription.
+     */
     public static function updateCounters(object $campaign, int $emailsSent, int $emailsFailed, int $emailsSkipped, int $emailsUnsubed): void
     {
 
@@ -556,6 +713,12 @@ class Campaigns
         update_post_meta($campaignPostId, 'emailsUnsubed', $emailsUnsubed);
     }
 
+    /**
+     * Returns the current email-send counters for a campaign.
+     *
+     * @param object $campaign Campaign object with an id property.
+     * @return object Object with emailsSend, emailsFailed, emailsSkipped, emailsUnsubed, emailsNewlyUnsubed.
+     */
     public static function getCounters(object $campaign): object
     {
         return (object)[
@@ -567,6 +730,11 @@ class Campaigns
         ];
     }
 
+    /**
+     * Increments the newly-unsubscribed counter and appends the current timestamp for attribution.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function incrementNewlyUnsubed(int $campaignPostId): void
     {
         $campaign = self::getCampaignById($campaignPostId);
@@ -577,6 +745,16 @@ class Campaigns
         }
     }
 
+    /**
+     * Records a link click for a campaign URL, updating all three click counters.
+     *
+     * Always increments linksClickedTotal. Increments linksClicked and uniqueUserClicks
+     * only when the session doesn't already carry them (prevents double-counting per session).
+     *
+     * @param string $campaignHash Campaign identifier hash.
+     * @param string $url          The URL that was clicked.
+     * @return int Updated per-session click count, or 0 if campaign not found.
+     */
     public static function linkCLicked(string $campaignHash, string $url): int
     {
         $campaign = self::getCampaignByHash($campaignHash);
@@ -623,6 +801,12 @@ class Campaigns
         return $newCount;
     }
 
+    /**
+     * Returns click counts grouped by day of week for a single campaign.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     * @return array Map of weekday name to click count.
+     */
     public static function getClickTimesByDayOfWeek(int $campaignPostId): array
     {
         $campaign = self::getCampaignById($campaignPostId);
@@ -664,6 +848,12 @@ class Campaigns
         return $dayStats;
     }
 
+    /**
+     * Returns aggregated click counts grouped by day of week across the last N campaigns.
+     *
+     * @param int $limit Number of recent campaigns to include (default 12).
+     * @return array Map of weekday name to total click count.
+     */
     public static function getClickTimesByDayOfWeekForLastCampaigns(int $limit = 12): array
     {
         $campaigns = self::getLastCampaigns($limit);
@@ -693,6 +883,12 @@ class Campaigns
         return $dayStats;
     }
 
+    /**
+     * Returns click counts grouped by hour of day (0–23) for a single campaign.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     * @return array Map of hour integer to click count.
+     */
     public static function getClickTimesByHourOfDay(int $campaignPostId): array
     {
         $campaign = self::getCampaignById($campaignPostId);
@@ -726,6 +922,12 @@ class Campaigns
         return $hourStats;
     }
 
+    /**
+     * Returns aggregated click counts grouped by hour of day across the last N campaigns.
+     *
+     * @param int $limit Number of recent campaigns to include (default 12).
+     * @return array Map of hour integer (0–23) to total click count.
+     */
     public static function getClickTimesByHourOfDayForLastCampaigns(int $limit = 12): array
     {
         $campaigns = self::getLastCampaigns($limit);
@@ -750,6 +952,14 @@ class Campaigns
         return $hourStats;
     }
 
+    /**
+     * Returns campaign start counts grouped by day of week for the last N campaigns.
+     *
+     * Used alongside getClickTimesByDayOfWeekForLastCampaigns() to compute the activity rating.
+     *
+     * @param int $limit Number of recent campaigns to include (default 12).
+     * @return array Map of weekday name to campaign start count.
+     */
     public static function getCampaignStartTimesByDayOfWeek(int $limit = 12): array
     {
         $campaigns = self::getLastCampaigns($limit);
@@ -776,6 +986,11 @@ class Campaigns
         return $dayStats;
     }
 
+    /**
+     * Starts the test phase: syncs unsubscribe status, records the start timestamp, and resets counters.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function testStart(int $campaignPostId): void
     {
         Subscribers::syncUnsubscribeStatus();
@@ -783,16 +998,31 @@ class Campaigns
         self::resetCounters($campaignPostId);
     }
 
+    /**
+     * Records the test phase completion timestamp.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function testFinish(int $campaignPostId): void
     {
         update_post_meta($campaignPostId, 'testFinished', time());
     }
 
+    /**
+     * Approves the test phase, allowing the campaign to proceed to full send.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function testApprove(int $campaignPostId): void
     {
         update_post_meta($campaignPostId, 'testApproved', time());
     }
 
+    /**
+     * Clears all test-phase timestamps so the campaign can be re-tested from scratch.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function testReset(int $campaignPostId): void
     {
         update_post_meta($campaignPostId, 'testStarted', false);
@@ -800,6 +1030,13 @@ class Campaigns
         update_post_meta($campaignPostId, 'testApproved', false);
     }
 
+    /**
+     * Starts the full campaign send: resets counters and records the start timestamp.
+     *
+     * Guard: does nothing if campaignStarted is already set, preventing double-start.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function campaignStart(int $campaignPostId): void
     {
         $campaign = self::getCampaignById($campaignPostId);
@@ -809,11 +1046,23 @@ class Campaigns
         }
     }
 
+    /**
+     * Records the campaign send completion timestamp.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function campaignFinish(int $campaignPostId): void
     {
         update_post_meta($campaignPostId, 'campaignFinished', time());
     }
 
+    /**
+     * Zeros all email-send and click counters for a campaign.
+     *
+     * Called at the start of each test phase and production send to ensure a clean slate.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function resetCounters(int $campaignPostId): void
     {
         update_post_meta($campaignPostId, 'emailsSend', 0);
@@ -826,6 +1075,14 @@ class Campaigns
         update_post_meta($campaignPostId, 'uniqueUserClicks', 0);
     }
 
+    /**
+     * Returns raw email-send and click stats for a campaign, formatted for bar-chart templates.
+     *
+     * Each stat key maps to an array of numeric values (one element per campaign in the input).
+     *
+     * @param object $campaign Campaign object with meta attached.
+     * @return array<string, int[]> Map of STAT_* constant to single-element numeric array.
+     */
     public static function getStatsForCampaign(object $campaign): array
     {
         $lastCampaigns = [$campaign];
@@ -859,6 +1116,15 @@ class Campaigns
         ];
     }
 
+    /**
+     * Returns percentage-based conversion stats for a campaign, formatted for bar-chart templates.
+     *
+     * Normalises each stat as a percentage of total attempted sends to allow comparison across
+     * campaigns with different list sizes.
+     *
+     * @param object $campaign Campaign object with meta attached.
+     * @return array<string, float[]> Map of STAT_* constant to single-element percentage array.
+     */
     public static function getConversionStatsForCampaign(object $campaign): array
     {
         $lastCampaigns = [$campaign];
@@ -903,6 +1169,12 @@ class Campaigns
         ];
     }
 
+    /**
+     * Returns raw email-send stats for the last N campaigns, formatted for dashboard bar charts.
+     *
+     * @param int $limit Number of recent campaigns to include.
+     * @return array<string, int[]> Map of STAT_* constant to array of values (one per campaign).
+     */
     public static function getDataForDashBoard(int $limit): array
     {
         $lastCampaigns = Campaigns::getLastCampaigns($limit);
@@ -936,6 +1208,12 @@ class Campaigns
         ];
     }
 
+    /**
+     * Returns percentage-based conversion stats for the last N campaigns, formatted for dashboard bar charts.
+     *
+     * @param int $limit Number of recent campaigns to include.
+     * @return array<string, float[]> Map of STAT_* constant to array of percentages (one per campaign).
+     */
     public static function getDataForDashBoardConversionRate(int $limit): array
     {
         $lastCampaigns = Campaigns::getLastCampaigns($limit);
@@ -980,6 +1258,14 @@ class Campaigns
         ];
     }
 
+    /**
+     * Returns monthly unsubscribe counts for the given number of past months.
+     *
+     * Counts unsubscribe events by reading unsub_time meta entries on campaign posts.
+     *
+     * @param int $months Number of months to look back (default 12).
+     * @return array Map of "Mon YYYY" label to unsubscribe count.
+     */
     public static function getUnsubscribeGrowthStats(int $months = 12): array
     {
         $stats = [];

--- a/classes/GravityForms.php
+++ b/classes/GravityForms.php
@@ -4,6 +4,7 @@ namespace Mawiblah;
 
 class GravityForms
 {
+    /** Hooks into gform_after_submission to update the last-interaction timestamp for known subscribers. */
     public static function init()
     {
         add_action('gform_after_submission', function ($entry, $form) {
@@ -23,12 +24,22 @@ class GravityForms
         }, 10, 2);
     }
 
+    /**
+     * Returns all Gravity Forms as a raw array from the GFAPI.
+     *
+     * @return array Array of Gravity Forms form objects.
+     */
     public static function getArrayOfGravityForms(): array
     {
         $GravityForms = \GFAPI::get_forms();
         return $GravityForms;
     }
 
+    /**
+     * Returns an array of form-ID / email-field-ID pairs for all forms that contain an email field.
+     *
+     * @return array Array of ['formId' => int, 'emailId' => int] maps.
+     */
     public static function getGravityFormWithEmailFieldIds()
     {
         $forms = self::getArrayOfGravityForms();
@@ -49,6 +60,12 @@ class GravityForms
         return $ids;
     }
 
+    /**
+     * Searches all Gravity Forms entries for a specific email address.
+     *
+     * @param string $email Email address to search for.
+     * @return array Map of found email addresses (deduplicated).
+     */
     public static function findEmail(string $email):array
     {
 
@@ -79,6 +96,11 @@ class GravityForms
         return $emails;
     }
 
+    /**
+     * Returns all unique email addresses from all Gravity Forms entries.
+     *
+     * @return array Deduplicated map of email → email strings.
+     */
     public static function getAllEmails(): array
     {
         $formsWihtEmailField = self::getGravityFormWithEmailFieldIds();
@@ -100,6 +122,12 @@ class GravityForms
         return $emails;
     }
 
+    /**
+     * Returns all email addresses and their submission dates for a specific Gravity Form.
+     *
+     * @param int $formId Gravity Forms form ID.
+     * @return array Map of email → ['email' => string, 'dateCreated' => string].
+     */
     public static function getAllEmailsForForm(int $formId): array
     {
         $form = \GFAPI::get_form($formId);
@@ -128,17 +156,34 @@ class GravityForms
     }
 
 
+    /**
+     * Returns the title of a Gravity Form.
+     *
+     * @param int $formId Gravity Forms form ID.
+     * @return string Form title.
+     */
     public static function getFormName(int $formId):string
     {
         $form = \GFAPI::get_form($formId);
         return $form['title'];
     }
 
+    /** Returns true if both the GFForms and GFAPI classes are available (Gravity Forms is active). */
     public static function isGravityPluginActive(): bool
     {
         return class_exists('GFForms') && class_exists('GFAPI');;
     }
 
+    /**
+     * Synchronises Gravity Forms entries with Mawiblah subscriber audiences.
+     *
+     * For each form, creates or reuses a matching audience taxonomy term and imports
+     * all entries as subscribers. Skips forms whose last entry predates the last sync
+     * date unless $force is true.
+     *
+     * @param bool $force When true, re-syncs all forms even if already up to date.
+     * @return array Sync stats: checked, skipped, forms_processed, subscribers_created, subscribers_updated, total_entries_processed.
+     */
     public static function syncWithAudiencePostType(bool $force = false):array
     {
         $forms = self::getArrayOfGravityForms();

--- a/classes/Helpers.php
+++ b/classes/Helpers.php
@@ -8,17 +8,31 @@ const KEYWORD_FOUND_EXACT_MATCH = 1;
 class Helpers
 {
 
+    /** Returns true if the current user has editor or administrator capabilities. */
     public static function canEdit()
     {
         return current_user_can('editor') || current_user_can('administrator');
     }
 
+    /**
+     * Returns all available email templates as a name-keyed array.
+     *
+     * @return array Map of template filename (without extension) to display label.
+     */
     public static function getArrayOfEmailTemplates(): array
     {
         return Templates::getArrayOfEmailTemplates();
     }
 
 
+    /**
+     * Creates and persists a new campaign post with the given name, audience, and template.
+     *
+     * @param string $name          Campaign title.
+     * @param array  $audience      Array of audience term IDs.
+     * @param string $emailTemplate Template filename.
+     * @return int|false New post ID on success, false if validation fails.
+     */
     public static function saveCampaign(string $name, array $audience, string $emailTemplate)
     {
         if (!Templates::validateEmailTemplate($emailTemplate)) {
@@ -48,6 +62,15 @@ class Helpers
         return $post_id;
     }
 
+    /**
+     * Builds a URL query string with standard UTM and subscriber tracking parameters.
+     *
+     * Merges utm_source, utm_medium, utm_campaign, and subscriber hash with any
+     * additional params provided by the caller.
+     *
+     * @param array $additionalParams Extra key-value pairs to merge into the query string.
+     * @return string Query string starting with '?'.
+     */
     public static function trackingParams(array $additionalParams = [])
     {
         $params = array_merge(
@@ -65,6 +88,7 @@ class Helpers
     }
 
 
+    /** Returns the current request URL path without the query string. */
     public static function getCurrentUrlPath()
     {
 
@@ -74,6 +98,7 @@ class Helpers
     }
 
 
+    /** Returns the full current request URL including scheme, host, and query string. */
     public static function getCurrentUrl()
     {
         $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off' || $_SERVER['SERVER_PORT'] == 443) ? "https://" : "http://";
@@ -83,6 +108,13 @@ class Helpers
         return $protocol . $host . $uri;
     }
 
+    /**
+     * Generates an admin action URL appended to the current URL, with a WP nonce included.
+     *
+     * @param array|null $params       Query parameters; must include 'action'.
+     * @param string     $nonceIdField Optional param key whose value is appended to the nonce action for per-item nonces.
+     * @return string Full URL with nonce query parameter.
+     */
     public static function generatePluginUrl(array|null $params, string $nonceIdField=""): string
     {
         if (!$params){
@@ -98,16 +130,44 @@ class Helpers
         return self::getCurrentUrl() . '&' . http_build_query($params);
     }
 
+    /**
+     * Generates a nonce-protected URL that resets the test state for a campaign.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     * @return string Admin action URL.
+     */
     public static function campaignTestResetUrl(int $campaignPostId): string
     {
         return self::generatePluginUrl(['action' => 'campaign-test-reset', 'campaignPostId' => $campaignPostId], 'campaignPostId');
     }
 
+    /**
+     * Generates a nonce-protected URL that approves the test phase for a campaign.
+     *
+     * @param int $campaignPostId Campaign post ID.
+     * @return string Admin action URL.
+     */
     public static function campaignTestApproveUrl(int $campaignPostId): string
     {
         return self::generatePluginUrl(['action' => 'campaign-test-approve', 'campaignPostId' => $campaignPostId], 'campaignPostId');
     }
 
+    /**
+     * Builds a normalised email-sending stats array for a single send attempt.
+     *
+     * Any non-zero skip reason (alreadySent, doNotDisturb, unsubscribed, emailsDisabled, notTester)
+     * automatically sets emailsSkipped to 1 so callers don't need to track this manually.
+     *
+     * @param int $sent           1 if email was sent successfully.
+     * @param int $skipped        1 if skipped for an unspecified reason.
+     * @param int $failed         1 if wp_mail() returned false.
+     * @param int $unsubscribed   1 if subscriber was already unsubscribed.
+     * @param int $alreadySent    1 if email was previously sent to this subscriber for this campaign.
+     * @param int $doNotDisturb   1 if the do-not-disturb threshold was not reached.
+     * @param int $emailsDisabled 1 if email sending is disabled in settings.
+     * @param int $notTester      1 if subscriber is not a tester in test mode.
+     * @return array Stats array with emailsSent, emailsFailed, emailsSkipped, and reason flags.
+     */
     public static function emailSendingStats(int $sent=0,int $skipped=0,int $failed=0,int $unsubscribed=0, int $alreadySent=-0, int $doNotDisturb=0, int $emailsDisabled=0, int $notTester=0 ): array{
         if ($alreadySent || $doNotDisturb || $unsubscribed || $emailsDisabled || $notTester) {
             $skipped = 1;
@@ -125,10 +185,24 @@ class Helpers
         ];
     }
 
+    /**
+     * Generates a stable subscriber hash from its post ID.
+     *
+     * @param int $id Subscriber post ID.
+     * @return string MD5 hash used as the public subscriber identifier.
+     */
     public static function generateSubscriberHash(int $id): string{
         return md5($id);
     }
 
+    /**
+     * Generates a campaign hash from its post ID and current timestamp.
+     *
+     * Includes time so that re-running a campaign produces a fresh hash for tracking purposes.
+     *
+     * @param int $id Campaign post ID.
+     * @return string MD5 hash used as the public campaign identifier.
+     */
     public static function generateCampaignHash(int $id): string{
         return md5($id . time());
     }

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -56,7 +56,7 @@ class Init
     /** Returns the full URL to the plugin settings page in the WordPress admin. */
     public static function get_settings_page_url()
     {
-        return esc_url(get_admin_url(null, 'options-general.php?page=' . self::get_settings_page_relative_path()));
+        return esc_url(get_admin_url(null, 'admin.php?page=' . self::MAWIBLAH_SETTINGS));
     }
 
 
@@ -152,7 +152,7 @@ class Init
      */
     public function add_settings_link($links)
     {
-        $settings_link = '<a href="admin.php?page=mawiblah-logs">' . __('Settings', 'mawiblah') . '</a>';
+        $settings_link = '<a href="' . esc_url(get_admin_url(null, 'admin.php?page=' . self::MAWIBLAH_SETTINGS)) . '">' . __('Settings', 'mawiblah') . '</a>';
         array_unshift($links, $settings_link);
         return $links;
     }

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -77,6 +77,25 @@ class Init
                 'permission_callback' => function () {
                     return current_user_can('edit_others_posts');
                 },
+                'args'                => [
+                    'campaignPostId' => [
+                        'type'     => 'integer',
+                        'required' => true,
+                    ],
+                    'subscriberId'   => [
+                        'type'     => 'integer',
+                        'required' => true,
+                    ],
+                    'email'          => [
+                        'type'              => 'string',
+                        'required'          => true,
+                        'sanitize_callback' => 'sanitize_email',
+                    ],
+                    'lastItem'       => [
+                        'type'    => 'boolean',
+                        'default' => false,
+                    ],
+                ],
             ));
 
             register_rest_route('mawiblah/v1', '/subscribe', array(
@@ -107,7 +126,7 @@ class Init
             ));
 
             register_rest_route('mawiblah/v1', '/unsubscribe', array(
-                'methods'             => \WP_REST_Server::ALLMETHODS,
+                'methods'             => [ \WP_REST_Server::READABLE, \WP_REST_Server::CREATABLE ],
                 'callback'            => 'Mawiblah\Unsubscribe::oneClickEndpoint',
                 'permission_callback' => '__return_true',
             ));

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -56,33 +56,54 @@ class Init
 
         add_action('rest_api_init', function () {
             register_rest_route('mawiblah/v1', '/get-html-template', array(
-                'methods' => 'POST',
-                'callback' => 'Mawiblah\RestRoutes::getHtmlTemplate',
+                'methods'             => \WP_REST_Server::CREATABLE,
+                'callback'            => 'Mawiblah\RestRoutes::getHtmlTemplate',
                 'permission_callback' => function () {
                     return current_user_can('edit_others_posts');
-                }
+                },
             ));
 
             register_rest_route('mawiblah/v1', '/test', array(
-                'methods' => 'GET',
-                'callback' => 'Mawiblah\RestRoutes::test',
+                'methods'             => \WP_REST_Server::READABLE,
+                'callback'            => 'Mawiblah\RestRoutes::test',
                 'permission_callback' => function () {
                     return current_user_can('edit_others_posts');
-                }
+                },
             ));
 
             register_rest_route('mawiblah/v1', '/send-email', array(
-                'methods' => 'POST',
-                'callback' => 'Mawiblah\RestRoutes::sendEmail',
+                'methods'             => \WP_REST_Server::CREATABLE,
+                'callback'            => 'Mawiblah\RestRoutes::sendEmail',
                 'permission_callback' => function () {
                     return current_user_can('edit_others_posts');
-                }
+                },
             ));
 
             register_rest_route('mawiblah/v1', '/subscribe', array(
-                'methods'             => 'POST',
+                'methods'             => \WP_REST_Server::CREATABLE,
                 'callback'            => 'Mawiblah\SubscriptionForm::subscribe',
                 'permission_callback' => '__return_true',
+                'args'                => [
+                    'email'          => [
+                        'type'              => 'string',
+                        'required'          => true,
+                        'sanitize_callback' => 'sanitize_email',
+                    ],
+                    'audienceHashes' => [
+                        'type'    => 'array',
+                        'default' => [],
+                        'items'   => ['type' => 'string'],
+                    ],
+                    'honeypot'       => [
+                        'type'    => 'string',
+                        'default' => '',
+                    ],
+                    'recaptchaToken' => [
+                        'type'              => 'string',
+                        'default'           => '',
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ],
+                ],
             ));
 
             register_rest_route('mawiblah/v1', '/unsubscribe', array(

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -15,6 +15,7 @@ class Init
 
     const MAWIBLAH_ACTIONS = 'mawiblah-actions';
     const MAWIBLAH_HELP    = 'mawiblah-help';
+    /** Bootstraps the plugin: runs migrations, registers admin menu, hooks, REST routes, and blocks. */
     public function init(): void
     {
         Migrations::run();
@@ -27,6 +28,7 @@ class Init
         add_filter('block_categories_all', [$this, 'registerBlockCategories'], 10, 2);
     }
 
+    /** Returns the array of all plugin admin page slugs used to conditionally enqueue assets. */
     public static function getIdsOfPages(){
         return [
             self::MAWIBLAH,
@@ -39,18 +41,26 @@ class Init
         ];
     }
 
+    /**
+     * Appends a Settings link to the plugin entry in the WP plugin list table.
+     *
+     * @param array $links Existing action links.
+     * @return array Modified links array.
+     */
     public static function add_settings_link_to_plugin_list($links)
     {
         $links[] = '<a href="' . self::get_settings_page_url() . '">Settings</a>';
         return $links;
     }
 
+    /** Returns the full URL to the plugin settings page in the WordPress admin. */
     public static function get_settings_page_url()
     {
         return esc_url(get_admin_url(null, 'options-general.php?page=' . self::get_settings_page_relative_path()));
     }
 
 
+    /** Registers all plugin REST API routes on the rest_api_init hook. */
     public function setup_api_routes(): void
     {
 
@@ -134,6 +144,12 @@ class Init
         });
     }
 
+    /**
+     * Prepends a Settings link in the plugin action links (admin bar variant).
+     *
+     * @param array $links Existing action links.
+     * @return array Modified links array.
+     */
     public function add_settings_link($links)
     {
         $settings_link = '<a href="admin.php?page=mawiblah-logs">' . __('Settings', 'mawiblah') . '</a>';
@@ -142,6 +158,7 @@ class Init
     }
 
 
+    /** Enqueues admin scripts and styles when the current page is a plugin admin page. */
     private function setup_hooks(): void
     {
         $pageIds = $this->getIdsOfPages();
@@ -153,11 +170,18 @@ class Init
         }
     }
 
+    /** Registers the subscriber custom post type and taxonomy (called during plugin bootstrap). */
     public function registerPostsTypesAndTaxamonies()
     {
         Subscribers::registerPostType();
     }
 
+    /**
+     * Registers the Gutenberg subscription-form block, its editor script, and render callback.
+     *
+     * Localises available audiences for the block editor via enqueue_block_editor_assets,
+     * filtering out system audiences (Unsubed, Testers).
+     */
     public function registerBlocks(): void
     {
         // Register the script early (before register_block_type references it)
@@ -215,6 +239,12 @@ class Init
         ]);
     }
 
+    /**
+     * Prepends the 'mawiblah' block category to the Gutenberg block inserter.
+     *
+     * @param array $categories Existing block categories.
+     * @return array Modified categories array.
+     */
     public function registerBlockCategories(array $categories): array
     {
         array_unshift($categories, [
@@ -225,6 +255,7 @@ class Init
         return $categories;
     }
 
+    /** Injects the WP REST nonce into the page as a JS global variable (mawiblahNonce) for admin AJAX calls. */
     public function my_custom_rest_api_nonce()
     {
 
@@ -237,18 +268,21 @@ class Init
         wp_add_inline_script( 'mawiblah-js', $inline_script);
     }
 
+    /** Enqueues the plugin's main admin stylesheet on plugin pages. */
     public function enqueue_plugin_styles(): void
     {
         wp_enqueue_style('mawiblah-css', MAWIBLAH_PLUGIN_URL . '/assets/css/mawiblah.css', [], MAWIBLAH_VERSION);
         //wp_enqueue_style('mawiblah-lib-table-styles', MAWIBLAH_PLUGIN_URL . '/assets/lib/jquery.dataTables.css', [], MAWIBLAH_VERSION);
     }
 
+    /** Enqueues the plugin's main admin JavaScript on plugin pages. */
     public function enqueue_plugin_scripts(): void
     {
         //wp_enqueue_script('mawiblah-lib-table-js', MAWIBLAH_PLUGIN_URL . '/assets/lib/jquery.dataTables.js.js', array('jquery'), MAWIBLAH_VERSION, true);
         wp_enqueue_script('mawiblah-main-js', MAWIBLAH_PLUGIN_URL . '/assets/js/mawiblah.js', ['mawiblah-js'], MAWIBLAH_VERSION);
     }
 
+    /** Registers the Mawiblah top-level menu and all submenus in the WordPress admin sidebar. */
     public function add_menu_links(): void
     {
         add_menu_page(
@@ -316,31 +350,38 @@ class Init
         );
     }
 
+    /** Admin page callback: renders the email templates list. */
     public function emailTemplates() {
         Renderer::emailTemplates();
     }
 
+    /** Admin page callback: renders the main plugin dashboard. */
     public function mawiblah()
     {
         Renderer::start();
     }
 
+    /** Admin page callback: renders the campaigns list and action pages. */
     public function campaigns() {
         Renderer::campaigns();
     }
 
+    /** Admin page callback: renders the test scenarios page. */
     public function tests() {
         Renderer::tests();
     }
 
+    /** Admin page callback: renders the plugin settings page. */
     public function settings() {
         Renderer::settings();
     }
 
+    /** Admin page callback: renders the actions/tools page. */
     public function actions() {
         Renderer::actions();
     }
 
+    /** Admin page callback: renders the in-plugin help page. */
     public function help() {
         Renderer::help();
     }

--- a/classes/Init.php
+++ b/classes/Init.php
@@ -85,6 +85,12 @@ class Init
                 'permission_callback' => '__return_true',
             ));
 
+            register_rest_route('mawiblah/v1', '/unsubscribe', array(
+                'methods'             => \WP_REST_Server::ALLMETHODS,
+                'callback'            => 'Mawiblah\Unsubscribe::oneClickEndpoint',
+                'permission_callback' => '__return_true',
+            ));
+
         });
     }
 

--- a/classes/Logs.php
+++ b/classes/Logs.php
@@ -6,21 +6,26 @@ class Logs
 {
 
     // exampel http://gudlenieks.test/?utm_source=email&utm_medium=email&utm_campaign=monthly-email&mawiblahId=%7BmawiblahId%7D&unsubscribe=%7Bemail%7D
+
+    /** Registers the log custom post type on init. */
     public static function init()
     {
         self::registerPostType();
     }
 
+    /** Returns true when database logging is enabled in Settings (debug mode set to "enable-db-log"). */
     public static function enabled()
     {
         return get_option('mawiblah-debug', false) === 'enable-db-log';
     }
 
+    /** Returns the custom post type slug for log entries. */
     public static function postType()
     {
         return MAWIBLAH_POST_TYPE_PREFIX . 'log';
     }
 
+    /** Registers the log custom post type with WordPress (admin-only, not public). */
     public static function registerPostType()
     {
 
@@ -39,16 +44,16 @@ class Logs
             'parent_item_colon' => __('Parent Logs:', 'mawiblah'),
             'not_found' => __('No Logs found.', 'mawiblah'),
             'not_found_in_trash' => __('No Logs found in Trash.', 'mawiblah'),
-            'featured_image' => _x('Log Cover Image', 'Overrides the “Featured Image” phrase for this post type. Added in 4.3', 'mawiblah'),
-            'set_featured_image' => _x('Set cover image', 'Overrides the “Set featured image” phrase for this post type. Added in 4.3', 'mawiblah'),
-            'remove_featured_image' => _x('Remove cover image', 'Overrides the “Remove featured image” phrase for this post type. Added in 4.3', 'mawiblah'),
-            'use_featured_image' => _x('Use as cover image', 'Overrides the “Use as featured image” phrase for this post type. Added in 4.3', 'mawiblah'),
-            'archives' => _x('Log archives', 'The post type archive label used in nav menus. Default “Post Archives”. Added in 4.4', 'mawiblah'),
-            'insert_into_item' => _x('Insert into Log', 'Overrides the “Insert into post”/“Insert into page” phrase (used when inserting media into a post). Added in 4.4', 'mawiblah'),
-            'uploaded_to_this_item' => _x('Uploaded to this Log', 'Overrides the “Uploaded to this post”/“Uploaded to this page” phrase (used when viewing media attached to a post). Added in 4.4', 'mawiblah'),
-            'filter_items_list' => _x('Filter Logs list', 'Screen reader text for the filter links heading on the post type listing screen. Default “Filter posts list”/“Filter pages list”. Added in 4.4', 'mawiblah'),
-            'items_list_navigation' => _x('Logs list navigation', 'Screen reader text for the pagination heading on the post type listing screen. Default “Posts list navigation”/“Pages list navigation”. Added in 4.4', 'mawiblah'),
-            'items_list' => _x('Logs list', 'Screen reader text for the items list heading on the post type listing screen. Default “Posts list”/“Pages list”. Added in 4.4', 'mawiblah'),
+            'featured_image' => _x('Log Cover Image', 'Overrides the "Featured Image" phrase for this post type. Added in 4.3', 'mawiblah'),
+            'set_featured_image' => _x('Set cover image', 'Overrides the "Set featured image" phrase for this post type. Added in 4.3', 'mawiblah'),
+            'remove_featured_image' => _x('Remove cover image', 'Overrides the "Remove featured image" phrase for this post type. Added in 4.3', 'mawiblah'),
+            'use_featured_image' => _x('Use as cover image', 'Overrides the "Use as featured image" phrase for this post type. Added in 4.3', 'mawiblah'),
+            'archives' => _x('Log archives', 'The post type archive label used in nav menus. Default "Post Archives". Added in 4.4', 'mawiblah'),
+            'insert_into_item' => _x('Insert into Log', 'Overrides the "Insert into post"/"Insert into page" phrase (used when inserting media into a post). Added in 4.4', 'mawiblah'),
+            'uploaded_to_this_item' => _x('Uploaded to this Log', 'Overrides the "Uploaded to this post"/"Uploaded to this page" phrase (used when viewing media attached to a post). Added in 4.4', 'mawiblah'),
+            'filter_items_list' => _x('Filter Logs list', 'Screen reader text for the filter links heading on the post type listing screen. Default "Filter posts list"/"Filter pages list". Added in 4.4', 'mawiblah'),
+            'items_list_navigation' => _x('Logs list navigation', 'Screen reader text for the pagination heading on the post type listing screen. Default "Posts list navigation"/"Pages list navigation". Added in 4.4', 'mawiblah'),
+            'items_list' => _x('Logs list', 'Screen reader text for the items list heading on the post type listing screen. Default "Posts list"/"Pages list". Added in 4.4', 'mawiblah'),
         ];
 
         $args = [
@@ -70,6 +75,14 @@ class Logs
         register_post_type(Logs::postType(), $args);
     }
 
+    /**
+     * Attaches log meta fields to a WP_Post object.
+     *
+     * Lazily generates a logId hash if one is not yet stored.
+     *
+     * @param object $post WP_Post instance.
+     * @return object The same post object with meta properties attached.
+     */
     public static function appendMeta($post)
     {
         $post->id = $post->ID;
@@ -89,6 +102,12 @@ class Logs
         return $post;
     }
 
+    /**
+     * Retrieves a single log entry by its WordPress post ID.
+     *
+     * @param int $id Post ID of the log entry.
+     * @return object|null Log object with meta, or null if not found.
+     */
     public static function getLog($id): object|null
     {
         $logById = get_post($id);
@@ -98,6 +117,17 @@ class Logs
         return null;
     }
 
+    /**
+     * Creates a new log entry if database logging is enabled.
+     *
+     * Additional objects are serialised as HTML into the post content for easy inspection
+     * in the WordPress admin.
+     *
+     * @param string $action            Short label stored as the post title.
+     * @param string $message           Human-readable message for the post content.
+     * @param array  $additionalObjects Key-value map of objects to append to the content.
+     * @return object|false New log object on success, false if logging is disabled or insert fails.
+     */
     public static function addLog(string $action, string $message = "", $additionalObjects = []): object|false
     {
         if (!self::enabled()) {
@@ -127,6 +157,13 @@ class Logs
         return false;
     }
 
+    /**
+     * Permanently deletes all log entries.
+     *
+     * Returns false immediately if logging is disabled.
+     *
+     * @return bool True on success, false if logging is disabled.
+     */
     public static function clearLogs(): bool
     {
         if (!self::enabled()) {
@@ -148,6 +185,13 @@ class Logs
         return true;
     }
 
+    /**
+     * Returns the total number of stored log entries.
+     *
+     * Returns 0 if logging is disabled.
+     *
+     * @return int Number of log entries.
+     */
     public static function getLogCount(): int
     {
         if (!self::enabled()) {

--- a/classes/Logs.php
+++ b/classes/Logs.php
@@ -52,18 +52,19 @@ class Logs
         ];
 
         $args = [
-            'labels' => $labels,
-            'public' => false,
+            'labels'          => $labels,
+            'public'          => false,
             'publicly_queryable' => false,
-            'show_ui' => true,
-            'show_in_menu' => true,
-            'query_var' => true,
-            'rewrite' => ['slug' => 'mawiblah-log'],
+            'show_ui'         => true,
+            'show_in_menu'    => true,
+            'query_var'       => true,
+            'rewrite'         => ['slug' => 'mawiblah-log'],
             'capability_type' => 'post',
-            'has_archive' => false,
-            'hierarchical' => false,
-            'menu_position' => null,
-            'supports' => ['title', 'editor'],
+            'has_archive'     => false,
+            'hierarchical'    => false,
+            'menu_position'   => null,
+            'menu_icon'       => 'dashicons-list-view',
+            'supports'        => ['title', 'editor'],
         ];
 
         register_post_type(Logs::postType(), $args);

--- a/classes/Migrations.php
+++ b/classes/Migrations.php
@@ -4,6 +4,12 @@ namespace Mawiblah;
 
 class Migrations
 {
+    /**
+     * Runs all pending database migrations in version order.
+     *
+     * Reads the stored schema version from options and applies only the migrations
+     * that have not yet run. Safe to call on every request.
+     */
     public static function run()
     {
         $currentVersion = get_option('mawiblah_db_version');
@@ -20,6 +26,12 @@ class Migrations
 
     }
 
+    /**
+     * Migrates campaign meta key from campaignId to campaignHash (introduced in 1.0.15).
+     *
+     * Copies existing campaignId values to campaignHash and removes the old key.
+     * Generates a new hash for campaigns that have neither key set.
+     */
     private static function migrateTo1015()
     {
         // Migration: Rename campaignId meta to campaignHash
@@ -44,6 +56,12 @@ class Migrations
         }
     }
 
+    /**
+     * Migrates subscriber meta key from subscriberId to subscriberHash (introduced in 1.0.16).
+     *
+     * Copies existing subscriberId values to subscriberHash and removes the old key.
+     * Generates a new hash for subscribers that have neither key set.
+     */
     private static function migrateTo1016()
     {
         // Migration: Rename subscriberId meta to subscriberHash

--- a/classes/Renderer.php
+++ b/classes/Renderer.php
@@ -3,32 +3,65 @@
 namespace Mawiblah;
 class Renderer
 {
+    /**
+     * Renders the main plugin dashboard page and exits.
+     *
+     * @param array|null $debug Optional debug data passed to the template.
+     */
     public static function start(array|null $debug = null)
     {
         include(MAWIBLAH_PLUGIN_DIR . "/templates/start.php");
         exit;
     }
 
+    /**
+     * Renders the "campaign already exists" notice partial.
+     *
+     * @param array|null $debug Optional debug data passed to the template.
+     */
     public static function campaign_already_exists(array|null $debug = null)
     {
         include_once MAWIBLAH_PLUGIN_DIR . "/templates/campaign/already-exists.php";
     }
 
+    /**
+     * Renders the "campaign validation failed" notice partial.
+     *
+     * @param array|null $debug Optional debug data passed to the template.
+     */
     public static function campaign_invalid(array|null $debug = null)
     {
         include_once MAWIBLAH_PLUGIN_DIR . "/templates/campaign/could-not-create.php";
     }
 
+    /**
+     * Renders the "campaign created successfully" notice partial.
+     *
+     * @param array|null $debug Optional debug data passed to the template.
+     */
     public static function campaign_created(array|null $debug = null)
     {
         include_once MAWIBLAH_PLUGIN_DIR . "/templates/campaign/created.php";
     }
 
+    /**
+     * Renders the "campaign could not be created" error partial.
+     *
+     * @param array|null $debug Optional debug data passed to the template.
+     */
     public static function campaign_could_not_create(array|null $debug = null)
     {
         include_once MAWIBLAH_PLUGIN_DIR . "/templates/campaign/could-not-create.php";
     }
 
+    /**
+     * Renders the campaigns admin page, dispatching to the correct sub-template based on the
+     * 'action' query parameter (list, create, edit, save, delete, test, approve, send, reset).
+     *
+     * Nonce and capability checks are applied to all write actions.
+     *
+     * @param array|null $debug Optional debug data passed to the template.
+     */
     public static function campaigns(array|null $debug = null)
     {
 
@@ -168,24 +201,28 @@ class Renderer
         }
     }
 
+    /** Renders the test scenarios page and exits. */
     public static function tests()
     {
         require MAWIBLAH_PLUGIN_DIR . "/templates/tests.php";
         exit;
     }
 
+    /** Renders the plugin settings page and exits. */
     public static function settings()
     {
         require MAWIBLAH_PLUGIN_DIR . "/templates/settings.php";
         exit;
     }
 
+    /** Renders the actions/tools admin page and exits. */
     public static function actions()
     {
         require MAWIBLAH_PLUGIN_DIR . "/templates/actions.php";
         exit;
     }
 
+    /** Renders the in-plugin help page and exits. */
     public static function help()
     {
         require MAWIBLAH_PLUGIN_DIR . "/templates/help.php";

--- a/classes/RestRoutes.php
+++ b/classes/RestRoutes.php
@@ -272,7 +272,20 @@ class RestRoutes
         }
         $emailBody = Campaigns::fillTemplate($template, $campaign, $subscriber);
 
-        $emailSendingResult = wp_mail($email, $campaign->subject, $emailBody);
+        $unsubToken = Subscribers::getUnsubToken($subscriber->id, $subscriber->email);
+        $unsubUrl   = add_query_arg([
+            'subscriber' => $subscriber->subscriberHash,
+            'token'      => $unsubToken,
+            'campaign'   => $campaign->campaignHash,
+        ], rest_url('mawiblah/v1/unsubscribe'));
+
+        $emailHeaders = [
+            'Content-Type: text/html; charset=UTF-8',
+            'List-Unsubscribe: <' . $unsubUrl . '>',
+            'List-Unsubscribe-Post: List-Unsubscribe=One-Click',
+        ];
+
+        $emailSendingResult = wp_mail($email, $campaign->subject, $emailBody, $emailHeaders);
 
         if ($emailSendingResult) {
 

--- a/classes/RestRoutes.php
+++ b/classes/RestRoutes.php
@@ -33,7 +33,7 @@ class RestRoutes
         $campaignPostId = absint($request->get_param('campaignPostId'));
         $subscriberId   = absint($request->get_param('subscriberId'));
         $email          = sanitize_email($request->get_param('email') ?? '');
-        $lastItem       = (bool) $request->get_param('lastItem');
+        $lastItem       = $request->get_param('lastItem');
 
         // Initialize or retrieve current counters
         $currentCounters = Campaigns::getCounters((object)['id' => $campaignPostId]);

--- a/classes/RestRoutes.php
+++ b/classes/RestRoutes.php
@@ -5,36 +5,35 @@ namespace Mawiblah;
 class RestRoutes
 {
 
-    public static function getHtmlTemplate(\WP_REST_Request $request)
+    public static function getHtmlTemplate(\WP_REST_Request $request): \WP_REST_Response
     {
-        $post = $request->get_json_params();
-
-        $template = $post['template'];
+        $template        = sanitize_text_field($request->get_param('template') ?? '');
         $templateContent = Templates::getEmailTemplateByName($template);
         $templateContent = do_shortcode($templateContent);
 
-        return [
-            'status' => 'ok',
-            'template' => $templateContent,
-            'templateName' => $template
-        ];
+        return new \WP_REST_Response([
+            'status'       => 'ok',
+            'template'     => $templateContent,
+            'templateName' => $template,
+        ], 200);
     }
 
-    public static function test(\WP_REST_Request $request)
+    public static function test(\WP_REST_Request $request): \WP_REST_Response
     {
-        return [
-            'status' => 'ok'
-        ];
+        return new \WP_REST_Response(['status' => 'ok'], 200);
     }
 
-    public static function sendEmail(\WP_REST_Request $request)
+    public static function sendEmail(\WP_REST_Request $request): \WP_REST_Response
     {
-        $post = $request->get_json_params();
+        return rest_ensure_response(self::processSendEmail($request));
+    }
 
-        $campaignPostId = $post['campaignPostId'];
-        $subscriberId = $post['subscriberId'];
-        $email = $post['email'];
-        $lastItem = $post['lastItem'] ?? false;
+    private static function processSendEmail(\WP_REST_Request $request): array
+    {
+        $campaignPostId = absint($request->get_param('campaignPostId'));
+        $subscriberId   = absint($request->get_param('subscriberId'));
+        $email          = sanitize_email($request->get_param('email') ?? '');
+        $lastItem       = (bool) $request->get_param('lastItem');
 
         // Initialize or retrieve current counters
         $currentCounters = Campaigns::getCounters((object)['id' => $campaignPostId]);
@@ -43,11 +42,11 @@ class RestRoutes
         $emailsSkipped = (int)($currentCounters->emailsSkipped ?? 0);
         $emailsUnsubed = (int)($currentCounters->emailsUnsubed ?? 0);
 
-        if (!is_numeric($campaignPostId) || !is_numeric($subscriberId)) {
+        if (!$campaignPostId || !$subscriberId) {
             return [
-                'stats' => Helpers::emailSendingStats(skipped:1),
-                'status' => 'error',
-                'message' => 'Campaign or subscriber missing'
+                'stats'   => Helpers::emailSendingStats(skipped: 1),
+                'status'  => 'error',
+                'message' => 'Campaign or subscriber missing',
             ];
         }
 

--- a/classes/RestRoutes.php
+++ b/classes/RestRoutes.php
@@ -5,6 +5,14 @@ namespace Mawiblah;
 class RestRoutes
 {
 
+    /**
+     * Returns a processed email template with all shortcodes evaluated.
+     *
+     * Requires editor capabilities. Used by the campaign editor to preview template output.
+     *
+     * @param \WP_REST_Request $request JSON body containing 'template' (template name string).
+     * @return \WP_REST_Response Template HTML content and template name.
+     */
     public static function getHtmlTemplate(\WP_REST_Request $request): \WP_REST_Response
     {
         $template        = sanitize_text_field($request->get_param('template') ?? '');
@@ -18,16 +26,36 @@ class RestRoutes
         ], 200);
     }
 
+    /** Connectivity smoke-test endpoint. Returns {"status":"ok"} with HTTP 200. */
     public static function test(\WP_REST_Request $request): \WP_REST_Response
     {
         return new \WP_REST_Response(['status' => 'ok'], 200);
     }
 
+    /**
+     * Sends one campaign email to one subscriber and updates campaign counters.
+     *
+     * This is the callback for the JS-driven per-subscriber send loop. It delegates
+     * to processSendEmail() and wraps the result in a WP_REST_Response.
+     *
+     * @param \WP_REST_Request $request JSON body: campaignPostId, subscriberId, email, lastItem.
+     * @return \WP_REST_Response Result payload with status, message, and emailSendingStats.
+     */
     public static function sendEmail(\WP_REST_Request $request): \WP_REST_Response
     {
         return rest_ensure_response(self::processSendEmail($request));
     }
 
+    /**
+     * Core send-email logic: validates inputs, applies all skip rules, sends via wp_mail(),
+     * and updates campaign counters.
+     *
+     * Skip rules (in order): unsubscribed, already sent, do-not-disturb threshold,
+     * email sending disabled in settings, not a tester in test mode, template unavailable.
+     *
+     * @param \WP_REST_Request $request
+     * @return array Result array consumed by sendEmail().
+     */
     private static function processSendEmail(\WP_REST_Request $request): array
     {
         $campaignPostId = absint($request->get_param('campaignPostId'));

--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -171,7 +171,10 @@ class Settings
             foreach ($s["fields"] as $fk => $f) {
 
                 if ($is_post && isset($_POST[$f["id"]])) {
-                    $value = sanitize_text_field(wp_unslash($_POST[$f["id"]]));
+                    $raw   = wp_unslash($_POST[$f["id"]]);
+                    $value = $f['type'] === 'textarea'
+                        ? sanitize_textarea_field($raw)
+                        : sanitize_text_field($raw);
                     update_option($f["id"], $value);
                     $sections[$sk]["fields"][$fk]["value"] = $value;
                     $options_updated = true;

--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -9,6 +9,7 @@ class Settings
     private static $messages = [];
     private static $permissionFailure = false;
 
+    /** Removes all plugin options and deletes generated files and directories on uninstall. */
     public static function uninstall()
     {
         // removing options
@@ -21,17 +22,20 @@ class Settings
         rmdir(MAWIBLAH_LOG_PATH);
     }
 
+    /** Plugin activation hook handler (currently a stub). */
     public static function activate()
     {
         //TODO
         // would be nice to show message with link to settings page
     }
 
+    /** Plugin deactivation hook handler. Resets the settings-page-visited flag. */
     public static function deactivate()
     {
         update_option("gae-settings-page-visited", 0);
     }
 
+    /** Settings init hook (currently a stub, registration is handled by get_sections). */
     public static function init()
     {
         //register settings
@@ -39,16 +43,19 @@ class Settings
         //self::add_scripts();
     }
 
+    /** Returns the full URL to the plugin settings page. */
     public static function get_settings_page_url()
     {
         return esc_url(get_admin_url(null, 'admin.php?page=' . self::get_settings_page_relative_path()));
     }
 
+    /** Returns the settings page slug constant. */
     public static function get_settings_page_relative_path()
     {
         return MAWIBLAH_SETTINGS_PAGE;
     }
 
+    /** Registers the plugin options page and adds the Settings link in the plugin list. */
     public static function create_menu()
     {
 
@@ -69,6 +76,14 @@ class Settings
 
     }
 
+    /**
+     * Returns the current debug level (0/1/2/3) based on the stored option value.
+     *
+     * Only applies if the current IP is in the allowed debug-IP list (when set).
+     * Returns false when debugging is disabled.
+     *
+     * @return int|false Debug level, or false if disabled.
+     */
     public static function debug()
     {
         # only run debug on localhost
@@ -105,6 +120,11 @@ class Settings
         return false;
     }
 
+    /**
+     * Returns the debug level for the current admin user based on their stored option value.
+     *
+     * @return int|false Debug level, or false if the user is not an administrator.
+     */
     public static function debug_admin()
     {
         $debug_level = 0;
@@ -137,11 +157,18 @@ class Settings
         }
         return false;
     }
+    /**
+     * Queues an admin notice message to be displayed on the settings page.
+     *
+     * @param string $text Message text.
+     * @param string $type Notice type: 'success' or 'error'.
+     */
     public static function add_message($text, $type = "success")
     {
         array_push(self::$messages, ["type" => $type, "message" => "MAWIBLAH: " . $text]);
     }
 
+    /** Reads all section field values from the database and then deletes those options. Called during uninstall. */
     private static function remove_sections_options()
     {
         $sections = json_decode(file_get_contents(MAWIBLAH_CONFIG_PATH . "/sections.json"), true);
@@ -155,6 +182,14 @@ class Settings
         }
     }
 
+    /**
+     * Returns all settings sections with current values loaded from the database.
+     *
+     * On POST (settings form submission), validates the nonce, sanitizes each value
+     * by field type, persists it via update_option(), and refreshes the asset version.
+     *
+     * @return array Settings sections with fields populated with their current values.
+     */
     public static function get_sections()
     {
         $options_updated = false;
@@ -189,6 +224,13 @@ class Settings
         return $sections;
     }
 
+    /**
+     * Outputs a single dismissible WordPress admin notice.
+     *
+     * @param int|string $id      Unique notice ID used in the element's HTML id attribute.
+     * @param string     $message Notice text.
+     * @param string     $type    Notice class suffix: 'success', 'error', 'warning', etc.
+     */
     public static function print_message($id, $message, $type)
     {
         ?>
@@ -203,6 +245,7 @@ class Settings
         <?php
     }
 
+    /** Outputs all queued admin notices added via add_message(). */
     public static function print_all_messages()
     {
         foreach (self::$messages as $id => $message) {
@@ -210,16 +253,19 @@ class Settings
         }
     }
 
+    /** Records that the settings page has been visited (used to suppress first-run notices). */
     public static function settings_page_visited()
     {
         update_option("gae-settings-page-visited", 1);
     }
 
+    /** Returns truthy if the settings page has been visited at least once, falsy otherwise. */
     public static function is_settings_page_visited()
     {
         return get_option("gae-settings-page-visited");
     }
 
+    /** Returns the number of unique translation strings collected so far (developer mode only). */
     public static function get_translation_count()
     {
         $translationIdsFile = MAWIBLAH_TRANSLATION_IDS_FILE;
@@ -230,6 +276,15 @@ class Settings
         return count($translationIds);
     }
 
+    /**
+     * Translates a string and optionally formats it with sprintf-style parameters.
+     *
+     * In developer mode, also records the string to the translation IDs file for POT generation.
+     *
+     * @param string       $text   String to translate.
+     * @param array|string $params Optional sprintf parameters.
+     * @return string Translated and formatted string.
+     */
     public static function get_translation($text, $params = [])
     {
 
@@ -279,6 +334,7 @@ class Settings
         return $text;
     }
 
+    /** Generates a .pot translation template file from the collected translation IDs (developer mode only). */
     public static function generate_pot_file()
     {
         if (MAWIBLAH_DEVELOPER) {
@@ -348,30 +404,36 @@ msgstr ""
         }
     }
 
+    /** Returns true when the "Send emails" setting is enabled (email sending is not suppressed). */
     public static function sendEmails():bool
     {
         return self::getOption("mawiblah-dont-send-emails") === 'send-emails';
     }
 
+    /** Returns the do-not-disturb threshold in seconds (minimum time between emails to the same subscriber). */
     public static function dontDisturbThreshold(){
         return self::getOption('mawiblah-dont-disturb-threshold');
     }
 
+    /** Returns true when reCAPTCHA v3 is set to "enabled" in settings (keys may still be missing). */
     public static function recaptchaEnabled(): bool
     {
         return self::getOption('mawiblah-recaptcha-enabled') === 'enabled';
     }
 
+    /** Returns the reCAPTCHA v3 site key (public, used in the browser). Empty string if not configured. */
     public static function recaptchaSiteKey(): string
     {
         return (string) self::getOption('mawiblah-recaptcha-site-key');
     }
 
+    /** Returns the reCAPTCHA v3 secret key (private, used server-side). Empty string if not configured. */
     public static function recaptchaSecretKey(): string
     {
         return (string) self::getOption('mawiblah-recaptcha-secret-key');
     }
 
+    /** Returns true only when reCAPTCHA is enabled AND both site key and secret key are non-empty. */
     public static function recaptchaReady(): bool
     {
         return self::recaptchaEnabled()
@@ -379,6 +441,12 @@ msgstr ""
             && self::recaptchaSecretKey() !== '';
     }
 
+    /**
+     * Returns a plugin option value, falling back to the field's default_value from sections.json.
+     *
+     * @param string $optionId WordPress option key matching a field id in sections.json.
+     * @return mixed Stored option value, or the field's default_value if not yet saved.
+     */
     public static function getOption($optionId)
     {
         // TODO: return default value if option not set

--- a/classes/Settings.php
+++ b/classes/Settings.php
@@ -161,13 +161,19 @@ class Settings
         $sectionsFile = MAWIBLAH_CONFIG_PATH . "/sections.json";
         $sections = json_decode(file_get_contents($sectionsFile), true);
 
+        $is_post = !empty($_POST);
+        if ($is_post) {
+            check_admin_referer('gae-settings-group-options');
+        }
+
         foreach ($sections as $sk => $s) {
 
             foreach ($s["fields"] as $fk => $f) {
 
-                if (isset($_POST[$f["id"]])) {
-                    update_option($f["id"], $_POST[$f["id"]]);
-                    $sections[$sk]["fields"][$fk]["value"] = $_POST[$f["id"]];
+                if ($is_post && isset($_POST[$f["id"]])) {
+                    $value = sanitize_text_field(wp_unslash($_POST[$f["id"]]));
+                    update_option($f["id"], $value);
+                    $sections[$sk]["fields"][$fk]["value"] = $value;
                     $options_updated = true;
                 } else {
                     $sections[$sk]["fields"][$fk]["value"] = get_option($f["id"]);

--- a/classes/ShortCodes.php
+++ b/classes/ShortCodes.php
@@ -5,6 +5,7 @@ namespace Mawiblah;
 class ShortCodes
 {
 
+    /** Registers all Mawiblah shortcodes with WordPress. */
     public static function register()
     {
         add_shortcode('mawiblah_subscribe_form', [ShortCodes::class, 'subscribeForm']);
@@ -29,6 +30,7 @@ class ShortCodes
         add_shortcode('mawiblah_unsubscribe', [ShortCodes::class, 'unsubscribe']);
     }
 
+    /** Returns the current post title, falling back to a month-based default. */
     public static function title()
     {
         $title = get_the_title();
@@ -38,6 +40,7 @@ class ShortCodes
         return sprintf(__('Summary for the %s', 'mawiblah'), date("F"));
     }
 
+    /** Returns the current post content, falling back to a default monthly newsletter message. */
     public static function content()
     {
         $content = get_the_content();
@@ -47,36 +50,48 @@ class ShortCodes
         return __('This is our montly report to you, hoepfully you will find something usefull', 'mawiblah');
     }
 
+    /** Returns the site URL for use in email templates. */
     public static function websiteUrl()
     {
         return get_site_url();
     }
 
+    /** Returns the site name for use as the logo alt text in email templates. */
     public static function logoAlt()
     {
         return get_bloginfo('name');
     }
 
+    /** Returns the custom logo HTML for use in email templates. */
     public static function logoSrc()
     {
         return get_custom_logo();
     }
 
+    /** Returns social profile links HTML for use in email templates. */
     public static function socialProfiles()
     {
         return '<a href="https://www.facebook.com/">Facebook</a>';
     }
 
+    /** Returns the default heading for the newest articles section in email templates. */
     public static function newestArticlesTitle()
     {
         return __('Check Out Our Latest Articles!', 'mawiblah');
     }
 
+    /** Returns the default introductory paragraph for the newest articles section. */
     public static function newestArticlesParagraph()
     {
         return __('Discover newest articles and printables for parents and kids.', 'mawiblah');
     }
 
+    /**
+     * Returns an HTML list of the most recent posts with campaign tracking links appended.
+     *
+     * @param array $atts Shortcode attributes; supports 'count' (default 5).
+     * @return string HTML <li> items for each recent post.
+     */
     public static function newestArticles($atts)
     {
         $atts = shortcode_atts(
@@ -101,16 +116,26 @@ class ShortCodes
         return $output;
     }
 
+    /** Returns the default sign-off heading for email templates. */
     public static function endTitle()
     {
         return __('Thank you for reading!', 'mawiblah');
     }
 
+    /** Returns the default sign-off paragraph for email templates. */
     public static function endContent()
     {
         return __('We hope you enjoyed our monthly newsletter. If you have any questions or suggestions, feel free to contact us.', 'mawiblah');
     }
 
+    /**
+     * Renders the subscription form HTML for the [mawiblah_subscribe_form] shortcode.
+     *
+     * Enqueues the form CSS and JS, then delegates rendering to SubscriptionForm::renderForm().
+     *
+     * @param array $atts Shortcode attributes: audiences, label, placeholder, button, success, error.
+     * @return string Rendered form HTML.
+     */
     public static function subscribeForm($atts): string
     {
         $atts = shortcode_atts([
@@ -142,6 +167,7 @@ class ShortCodes
         return SubscriptionForm::renderForm($hashes, $options);
     }
 
+    /** Returns an unsubscribe anchor tag with subscriber and campaign tracking parameters pre-filled as template placeholders. */
     public static function unsubscribe()
     {
 

--- a/classes/Subscribers.php
+++ b/classes/Subscribers.php
@@ -80,18 +80,19 @@ class Subscribers
         ];
 
         $args = [
-            'labels' => $labels,
-            'public' => false,
+            'labels'          => $labels,
+            'public'          => false,
             'publicly_queryable' => false,
-            'show_ui' => true,
-            'show_in_menu' => true,
-            'query_var' => true,
-            'rewrite' => ['slug' => 'mawiblah-subscriber'],
+            'show_ui'         => true,
+            'show_in_menu'    => true,
+            'query_var'       => true,
+            'rewrite'         => ['slug' => 'mawiblah-subscriber'],
             'capability_type' => 'post',
-            'has_archive' => false,
-            'hierarchical' => false,
-            'menu_position' => null,
-            'supports' => ['title'],
+            'has_archive'     => false,
+            'hierarchical'    => false,
+            'menu_position'   => null,
+            'menu_icon'       => 'dashicons-groups',
+            'supports'        => ['title'],
         ];
 
         register_post_type(Subscribers::postType(), $args);

--- a/classes/Subscribers.php
+++ b/classes/Subscribers.php
@@ -6,6 +6,7 @@ class Subscribers
 {
 
     // exampel http://gudlenieks.test/?utm_source=email&utm_medium=email&utm_campaign=monthly-email&mawiblahId=%7BmawiblahId%7D&unsubscribe=%7Bemail%7D
+    /** Registers the subscriber post type, ensures default audiences exist, and adds admin meta boxes. */
     public static function init()
     {
         self::registerPostType();
@@ -13,12 +14,14 @@ class Subscribers
         add_action('add_meta_boxes', [self::class, 'addMetaBoxes']);
     }
 
+    /** Creates the Unsubed and Testers audiences if they do not already exist. */
     public static function ensureDefaultAudiences(): void
     {
         self::unsubedAudience();
         self::testerAudience();
     }
 
+    /** Registers the subscriber metadata meta box on the subscriber edit screen. */
     public static function addMetaBoxes()
     {
 
@@ -32,6 +35,11 @@ class Subscribers
         );
     }
 
+    /**
+     * Renders the subscriber metadata meta box content in the WP admin.
+     *
+     * @param \WP_Post $post The subscriber post being edited.
+     */
     public static function renderMetaData($post)
     {
         // Add your custom output here
@@ -44,11 +52,13 @@ class Subscribers
         echo '</div>';
     }
 
+    /** Returns the custom post type slug for subscribers. */
     public static function postType()
     {
         return MAWIBLAH_POST_TYPE_PREFIX . 'subscriber';
     }
 
+    /** Registers the subscriber custom post type and its audience taxonomy with WordPress. */
     public static function registerPostType()
     {
 
@@ -124,6 +134,7 @@ class Subscribers
         register_taxonomy(Subscribers::postType() . '_category', [Subscribers::postType()], $taxonomy_args);
     }
 
+    /** Returns the map of subscriber meta keys and their default values. */
     public static function getMetaKeys()
     {
         return [
@@ -162,12 +173,20 @@ class Subscribers
         ];
     }
 
+    /**
+     * Attaches all subscriber meta fields to a WP_Post object.
+     *
+     * Lazily generates and persists a subscriberHash if one is not yet stored.
+     *
+     * @param object|null $post WP_Post instance to decorate.
+     * @return object|null The decorated post, or null if $post was null.
+     */
     public static function appendMeta($post)
     {
         if (!$post) {
             return null;
         }
-        
+
         $post->id = $post->ID ?? $post->id;
         $post->email = get_post_meta($post->id, 'email', true);
         $post->subscriberHash = get_post_meta($post->id, 'subscriberHash', true);
@@ -187,6 +206,12 @@ class Subscribers
         return $post;
     }
 
+    /**
+     * Returns a flat map of all subscriber meta key-value pairs for a given post ID.
+     *
+     * @param int $postId Subscriber post ID.
+     * @return array Map of meta key to meta value.
+     */
     public static function getMetaData($postId)
     {
         $metaKeys = self::getMetaKeys();
@@ -197,6 +222,12 @@ class Subscribers
         return $metaData;
     }
 
+    /**
+     * Finds a subscriber by email address.
+     *
+     * @param string $email Email address to look up.
+     * @return object|null Subscriber object with meta attached, or null if not found.
+     */
     public static function getSubscriber($email): object|null
     {
         $subscriber = get_posts([
@@ -217,6 +248,14 @@ class Subscribers
         return null;
     }
 
+    /**
+     * Attaches meta fields to an audience term object.
+     *
+     * Lazily generates and stores the audienceHash (MD5 of term_id) if not yet present.
+     *
+     * @param object $audience WP_Term object to decorate.
+     * @return object The decorated term with gravityFormsId, lastSyncDate, id, and audienceHash.
+     */
     static function appendAudienceMeta($audience)
     {
         $audience->gravityFormsId = get_term_meta($audience->term_id, 'gravityFormsId', true);
@@ -233,6 +272,12 @@ class Subscribers
         return $audience;
     }
 
+    /**
+     * Finds an audience term by its audienceHash.
+     *
+     * @param string $audienceHash MD5 audience hash.
+     * @return object|null Audience term with meta, or null if not found.
+     */
     public static function getAudienceByHash(string $audienceHash): ?object
     {
         $audiences = self::getAllAudiences();
@@ -244,6 +289,12 @@ class Subscribers
         return null;
     }
 
+    /**
+     * Returns a single audience term with meta attached, looked up by its term ID.
+     *
+     * @param int $audienceId Taxonomy term ID.
+     * @return object|null Audience term with meta, or null if not found.
+     */
     public static function getAudience($audienceId)
     {
         $audience = get_term($audienceId, Subscribers::postType() . '_category');
@@ -255,6 +306,14 @@ class Subscribers
         return null;
     }
 
+    /**
+     * Returns all subscriber audience terms, each decorated with meta (including audienceHash).
+     *
+     * System audiences (Unsubed, Testers) are included; callers that need only user-facing
+     * audiences should filter them out.
+     *
+     * @return array Array of decorated audience term objects.
+     */
     public static function getAllAudiences(): array
     {
         $audiences = get_terms([
@@ -274,6 +333,12 @@ class Subscribers
         return $result;
     }
 
+    /**
+     * Returns all subscribers belonging to a specific audience.
+     *
+     * @param int $audienceId Audience taxonomy term ID.
+     * @return array Array of subscriber objects with meta attached.
+     */
     public static function getSubscribersByAudience(int $audienceId): array
     {
         $args = [
@@ -306,6 +371,13 @@ class Subscribers
         return $subscribers;
     }
 
+    /**
+     * Creates a new subscriber with the given email, or returns the existing one if the email already exists.
+     *
+     * @param string $email          Email address of the subscriber.
+     * @param string $subscriberHash Optional pre-computed hash; auto-generated if empty.
+     * @return object Subscriber object with meta attached.
+     */
     public static function addSubscriber(string $email, string $subscriberHash = ""): object
     {
         $existing = self::getSubscriber($email);
@@ -335,6 +407,15 @@ class Subscribers
         return self::getSubscriber($email);
     }
 
+    /**
+     * Returns the unsubscribe token for a subscriber, generating and persisting it if not yet set.
+     *
+     * The token is an MD5 of the subscriber's post ID and email address.
+     *
+     * @param string|int $subId    Subscriber post ID (or email if ID is unknown).
+     * @param string     $subEmail Subscriber email, used for lookup when ID is unavailable.
+     * @return string Unsubscribe token.
+     */
     public static function getUnsubToken(string|int $subId, string $subEmail = "")
     {
         $id = $subId;
@@ -353,6 +434,17 @@ class Subscribers
 
     }
 
+    /**
+     * Marks a subscriber as unsubscribed after validating their token.
+     *
+     * Sets the unsubed flag, stores the feedback, adds them to the Unsubed audience,
+     * and records the unsubscribe timestamp.
+     *
+     * @param string $email      Subscriber email address.
+     * @param string $unsubToken Token from the confirmation URL.
+     * @param string $feedback   Optional feedback reason provided by the subscriber.
+     * @return bool True on success, false if the token does not match.
+     */
     public static function unsub($email, $unsubToken, $feedback)
     {
         $subscriber = self::getSubscriber($email);
@@ -373,6 +465,12 @@ class Subscribers
         }
     }
 
+    /**
+     * Returns true if all given audience IDs exist as valid taxonomy terms.
+     *
+     * @param int[] $audiences Array of audience term IDs to validate.
+     * @return bool False if the array is empty or any ID is not a valid term.
+     */
     public static function validateAudiences(array $audiences): bool
     {
         if (empty($audiences)) {
@@ -393,6 +491,14 @@ class Subscribers
         return true;
     }
 
+    /**
+     * Returns the audience term linked to a Gravity Forms form ID, creating it if needed.
+     *
+     * @param int    $gravityFormId The Gravity Forms form ID.
+     * @param string $title         Title for a new audience if one needs to be created.
+     * @param string $description   Description for a new audience.
+     * @return object|null Audience term with meta, or null if not found and no title was provided.
+     */
     public static function getGFAudience($gravityFormId, $title = "", $description = ""): object|null
     {
         $listOfTaxanomies = get_terms([
@@ -418,6 +524,14 @@ class Subscribers
     }
 
     // to do check this return types...
+    /**
+     * Creates a new audience taxonomy term and optionally links it to a Gravity Forms form.
+     *
+     * @param string $title         Audience name.
+     * @param string $description   Audience description.
+     * @param int    $gravityFormsId Gravity Forms form ID to link (0 for none).
+     * @return array|object|null New term data with meta, or null on failure.
+     */
     public static function createAudience($title, $description, $gravityFormsId): array|object|null
     {
         $term = wp_insert_term($title, Subscribers::postType() . '_category', ['description' => $description]);
@@ -427,6 +541,14 @@ class Subscribers
         return self::appendAudienceMeta((object)$term);
     }
 
+    /**
+     * Assigns a subscriber to an audience and syncs the unsubed meta flag when appropriate.
+     *
+     * Adding to the Unsubed audience also sets unsubed=true on the subscriber post.
+     *
+     * @param int $subscriberId Subscriber post ID.
+     * @param int $audienceId   Audience taxonomy term ID.
+     */
     public static function addSubscriberToAudience(int $subscriberId, int $audienceId): void
     {
         wp_set_post_terms($subscriberId, $audienceId, Subscribers::postType() . '_category', true);
@@ -443,6 +565,12 @@ class Subscribers
         }
     }
 
+    /**
+     * Returns true if the given email appears in the Mailchimp unsubscribed CSV import file.
+     *
+     * @param string $email Email address to check.
+     * @return bool True if the email is in the Mailchimp unsub list, false otherwise.
+     */
     public static function checkMailchimpUnsubedAudience($email): bool
     {
         // load file
@@ -462,6 +590,7 @@ class Subscribers
         return false;
     }
 
+    /** Returns the "Unsubed" system audience term, creating it if it does not exist. */
     public static function unsubedAudience()
     {
         $term = get_term_by('name', 'Unsubed', Subscribers::postType() . '_category');
@@ -475,6 +604,13 @@ class Subscribers
         return $term;
     }
 
+    /**
+     * Returns true if a campaign email has already been sent to this subscriber.
+     *
+     * @param int $subscriberId   Subscriber post ID.
+     * @param int $campaignPostId Campaign post ID.
+     * @return bool
+     */
     public static function isEmailSent(int $subscriberId, int $campaignPostId): bool
     {
         $sent = get_post_meta($subscriberId, 'sent_' . $campaignPostId, true);
@@ -482,6 +618,12 @@ class Subscribers
         return (bool)$sent;
     }
 
+    /**
+     * Returns true if the subscriber is flagged as a tester (either via meta or Testers audience membership).
+     *
+     * @param object $subscriber Subscriber object with meta and audiences attached.
+     * @return bool
+     */
     public static function isTester($subscriber): bool
     {
         $testerFlag = get_post_meta($subscriber->id, 'tester', true);
@@ -498,6 +640,7 @@ class Subscribers
         return $testerFlag || $inTesterAudience;
     }
 
+    /** Returns the "Testers" system audience term, creating it if it does not exist. */
     public static function testerAudience()
     {
         $term = get_term_by('name', 'Testers', Subscribers::postType() . '_category');
@@ -511,6 +654,12 @@ class Subscribers
         return $term;
     }
 
+    /**
+     * Updates the subscriber's last interaction timestamp, setting first interaction if not yet recorded.
+     *
+     * @param int      $subscriberId    Subscriber post ID.
+     * @param int|null $interactionDate Unix timestamp; defaults to now.
+     */
     public static function updateLastInteraction(int $subscriberId, int|null $interactionDate = null): void
     {
         $interactionDate = $interactionDate ?? time();
@@ -530,22 +679,46 @@ class Subscribers
         update_post_meta($subscriberId, 'lastInteraction', $interactionDate);
     }
 
+    /**
+     * Marks an email send as in-progress for a subscriber/campaign pair.
+     *
+     * @param int $subscriberId   Subscriber post ID.
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function sendingEmail(int $subscriberId, int $campaignPostId): void
     {
         update_post_meta($subscriberId, 'sent_' . $campaignPostId, 'sending');
     }
 
+    /**
+     * Marks an email as successfully sent and updates the last interaction timestamp.
+     *
+     * @param int $subscriberId   Subscriber post ID.
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function sentEmail(int $subscriberId, int $campaignPostId): void
     {
         update_post_meta($subscriberId, 'sent_' . $campaignPostId, 'sent');
         self::updateLastInteraction($subscriberId);
     }
 
+    /**
+     * Marks an email send as failed for a subscriber/campaign pair.
+     *
+     * @param int $subscriberId   Subscriber post ID.
+     * @param int $campaignPostId Campaign post ID.
+     */
     public static function sentEmailFailed(int $subscriberId, int $campaignPostId): void
     {
         update_post_meta($subscriberId, 'sent_' . $campaignPostId, 'failed');
     }
 
+    /**
+     * Retrieves a subscriber by their WordPress post ID.
+     *
+     * @param int $id Subscriber post ID.
+     * @return object|null Subscriber with meta, or null if not found.
+     */
     public static function getSubscriberById(int $id): object|null
     {
 
@@ -556,6 +729,12 @@ class Subscribers
         return null;
     }
 
+    /**
+     * Retrieves a subscriber by their public subscriberHash identifier.
+     *
+     * @param string $subscriberHash MD5 hash stored in the subscriberHash meta field.
+     * @return object|null Subscriber with meta, or null if not found.
+     */
     public static function getSubscriberBySubscriberHash(string $subscriberHash)
     {
 
@@ -577,6 +756,13 @@ class Subscribers
         return self::appendMeta($postsByMeta[0]);
     }
 
+    /**
+     * Increments the subscriber's total activity counter and, when not already counted in
+     * the current session, the per-session activity counter.
+     *
+     * @param string $subscriberHash Subscriber identifier hash.
+     * @return int|null Updated per-session activity count, or null if subscriber not found.
+     */
     public static function linksClicked($subscriberHash)
     {
         $subscriber = self::getSubscriberBySubscriberHash($subscriberHash);
@@ -610,6 +796,12 @@ class Subscribers
      * @param string|null $date Optional date to set if no last sync date exists
      * @return string|false The last sync date or false if not found and no date was provided
      */
+    /**
+     * Returns the Unix timestamp of the last sync for an audience, initialising it to now if absent.
+     *
+     * @param int $audienceId Audience taxonomy term ID.
+     * @return int|false Unix timestamp, or false on failure.
+     */
     public static function getLastSyncDate(int $audienceId): int|false
     {
         $lastSyncDate = get_term_meta($audienceId, 'lastSyncDate', true);
@@ -623,16 +815,34 @@ class Subscribers
         return $lastSyncDate;
     }
 
+    /**
+     * Persists the last sync date for a Gravity Forms-linked audience.
+     *
+     * @param int $audienceId Audience taxonomy term ID.
+     * @param int $date       Unix timestamp of the most recent Gravity Forms entry.
+     */
     public static function updateLastSyncDate(int $audienceId, int $date):void
     {
         update_term_meta($audienceId, 'lastSyncDate', $date);
     }
 
+    /**
+     * Sets the first interaction timestamp for a subscriber.
+     *
+     * @param int $subscriberId Subscriber post ID.
+     * @param int $time         Unix timestamp.
+     */
     public static function updateFirstInteraction(int $subscriberId, int $time):void
     {
         update_post_meta($subscriberId, 'firstInteraction', $time);
     }
 
+    /**
+     * Returns monthly subscriber growth counts for the given number of past months.
+     *
+     * @param int $months Number of months to look back (default 12).
+     * @return array Map of "Mon YYYY" label to new subscriber count.
+     */
     public static function getSubscriberGrowthStats(int $months = 12): array
     {
         global $wpdb;
@@ -672,6 +882,12 @@ class Subscribers
         return $formattedStats;
     }
 
+    /**
+     * Bidirectionally synchronises the unsubed meta flag and the Unsubed audience membership.
+     *
+     * Subscribers in the Unsubed audience get unsubed=true; subscribers with unsubed=true
+     * get added to the Unsubed audience. Runs as a maintenance utility.
+     */
     public static function syncUnsubscribeStatus(): void
     {
         $unsubedAudience = self::unsubedAudience();
@@ -729,6 +945,12 @@ class Subscribers
         }
     }
 
+    /**
+     * Returns the most recent unsubscribe feedback entries.
+     *
+     * @param int $limit Maximum number of entries to return (default 20).
+     * @return array Array of ['feedback' => string, 'date' => string] maps, newest first.
+     */
     public static function getUnsubscribeReasons(int $limit = 20): array
     {
         global $wpdb;

--- a/classes/SubscriptionForm.php
+++ b/classes/SubscriptionForm.php
@@ -7,6 +7,7 @@ class SubscriptionForm
     const RECAPTCHA_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
     const RECAPTCHA_THRESHOLD  = 0.5;
 
+    /** Intercepts the re-subscribe confirmation URL on WordPress init and processes the token. */
     public static function init(): void
     {
         if (isset($_GET['mawiblah-resubscribe'])) {
@@ -14,6 +15,13 @@ class SubscriptionForm
         }
     }
 
+    /**
+     * Renders the subscription form HTML, conditionally loading reCAPTCHA v3 if fully configured.
+     *
+     * @param string[] $audienceHashes Audience hashes to embed as hidden inputs.
+     * @param array    $options        Optional overrides: label, placeholder, buttonText, successMessage, errorMessage.
+     * @return string Rendered form HTML.
+     */
     public static function renderForm(array $audienceHashes = [], array $options = []): string
     {
         $siteKey        = Settings::recaptchaSiteKey();
@@ -28,6 +36,15 @@ class SubscriptionForm
         return ob_get_clean();
     }
 
+    /**
+     * REST endpoint callback for POST /wp-json/mawiblah/v1/subscribe.
+     *
+     * Applies honeypot and reCAPTCHA checks before delegating to subscribeByEmail().
+     * Returns HTTP 400 on validation or spam-check failure, HTTP 200 otherwise.
+     *
+     * @param \WP_REST_Request $request JSON body: email, audienceHashes, honeypot, recaptchaToken.
+     * @return \WP_REST_Response
+     */
     public static function subscribe(\WP_REST_Request $request): \WP_REST_Response
     {
         $email          = sanitize_email($request->get_param('email') ?? '');
@@ -102,6 +119,12 @@ class SubscriptionForm
         return ['status' => 'ok', 'message' => __('You are now subscribed!', 'mawiblah')];
     }
 
+    /**
+     * Sends a re-subscribe confirmation email containing a token-bearing URL.
+     *
+     * @param object $subscriber  Subscriber object with email, subscriberHash, and id.
+     * @param int[]  $audienceIds Audience term IDs to restore on confirmation.
+     */
     private static function sendResubscribeEmail(object $subscriber, array $audienceIds): void
     {
         $token        = Subscribers::getUnsubToken($subscriber->id, $subscriber->email);
@@ -122,6 +145,7 @@ class SubscriptionForm
         wp_mail($subscriber->email, $subject, $body);
     }
 
+    /** Reads resubscribe URL parameters, calls confirmResubscribe(), and renders the result template. Exits. */
     private static function handleResubscribeConfirmation(): void
     {
         $subscriberHash = sanitize_text_field($_GET['subscriber'] ?? '');
@@ -138,6 +162,14 @@ class SubscriptionForm
         exit;
     }
 
+    /**
+     * Validates a re-subscribe token and, if valid, clears the unsubed flag and restores audience memberships.
+     *
+     * @param string $subscriberHash Subscriber identifier hash from the confirmation URL.
+     * @param string $resubToken     Token to validate against the stored unsubToken.
+     * @param string $audienceParam  Comma-separated audience term IDs to restore.
+     * @return bool True if resubscription succeeded, false if subscriber not found or token invalid.
+     */
     public static function confirmResubscribe(string $subscriberHash, string $resubToken, string $audienceParam): bool
     {
         $subscriber = Subscribers::getSubscriberBySubscriberHash($subscriberHash);
@@ -175,6 +207,14 @@ class SubscriptionForm
         return true;
     }
 
+    /**
+     * Verifies a reCAPTCHA v3 token against the Google siteverify API.
+     *
+     * Returns false immediately for empty tokens. Requires a score >= RECAPTCHA_THRESHOLD (0.5).
+     *
+     * @param string $token reCAPTCHA v3 token from the browser.
+     * @return bool True if verification passed, false otherwise.
+     */
     private static function verifyRecaptcha(string $token): bool
     {
         if (empty($token)) {

--- a/classes/SubscriptionForm.php
+++ b/classes/SubscriptionForm.php
@@ -28,27 +28,28 @@ class SubscriptionForm
         return ob_get_clean();
     }
 
-    public static function subscribe(\WP_REST_Request $request): array
+    public static function subscribe(\WP_REST_Request $request): \WP_REST_Response
     {
-        $body           = $request->get_json_params();
-        $email          = sanitize_email($body['email'] ?? '');
-        $audienceHashes = array_map('sanitize_text_field', (array) ($body['audienceHashes'] ?? []));
-        $honeypot       = $body['honeypot'] ?? '';
-        $recaptchaToken = sanitize_text_field($body['recaptchaToken'] ?? '');
+        $email          = sanitize_email($request->get_param('email') ?? '');
+        $audienceHashes = array_map('sanitize_text_field', (array) ($request->get_param('audienceHashes') ?? []));
+        $honeypot       = $request->get_param('honeypot') ?? '';
+        $recaptchaToken = sanitize_text_field($request->get_param('recaptchaToken') ?? '');
 
         // Honeypot — silently succeed so bots think it worked
         if (!empty($honeypot)) {
-            return ['status' => 'ok', 'message' => __('You are now subscribed!', 'mawiblah')];
+            return new \WP_REST_Response(['status' => 'ok', 'message' => __('You are now subscribed!', 'mawiblah')], 200);
         }
 
         // reCAPTCHA v3
         if (Settings::recaptchaReady()) {
             if (!self::verifyRecaptcha($recaptchaToken)) {
-                return ['status' => 'error', 'message' => __('Verification failed. Please try again.', 'mawiblah')];
+                return new \WP_REST_Response(['status' => 'error', 'message' => __('Verification failed. Please try again.', 'mawiblah')], 400);
             }
         }
 
-        return self::subscribeByEmail($email, $audienceHashes);
+        $result = self::subscribeByEmail($email, $audienceHashes);
+        $status = $result['status'] === 'error' ? 400 : 200;
+        return new \WP_REST_Response($result, $status);
     }
 
     /**
@@ -89,9 +90,9 @@ class SubscriptionForm
         }
 
         // Add to audiences (only those not already assigned)
+        $existingTerms = wp_get_post_terms($subscriber->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
         foreach ($audienceIds as $audienceId) {
-            $terms = wp_get_post_terms($subscriber->id, Subscribers::postType() . '_category', ['fields' => 'ids']);
-            if (!in_array($audienceId, $terms)) {
+            if (!in_array($audienceId, $existingTerms)) {
                 Subscribers::addSubscriberToAudience($subscriber->id, $audienceId);
             }
         }

--- a/classes/Templates.php
+++ b/classes/Templates.php
@@ -4,6 +4,15 @@ namespace Mawiblah;
 class Templates
 {
 
+    /**
+     * Fetches a processed email template via an internal REST request.
+     *
+     * Used during campaign sending to retrieve templates with WPML-aware shortcode evaluation,
+     * because the REST call ensures WPML is fully initialised before shortcodes run.
+     *
+     * @param string $templateName Template filename without extension.
+     * @return string|bool Processed HTML string, or false on failure.
+     */
     public static function getTemplateByNameViaRest($templateName): string | bool
     {
         $cookies = [];
@@ -37,6 +46,14 @@ class Templates
         return $data->template ?? false;
     }
 
+    /**
+     * Returns the ordered list of directories to search for email templates.
+     *
+     * Search order: child theme → parent theme → plugin. This allows themes to override
+     * plugin-bundled templates by placing HTML files in their mawiblah/email_templates/ directory.
+     *
+     * @return array<string, string> Map of label to directory path.
+     */
     private static function getEmailTemplateDirectories(): array
     {
         $dirs = [];
@@ -55,6 +72,14 @@ class Templates
         return $dirs;
     }
 
+    /**
+     * Returns the raw HTML content of an email template by name.
+     *
+     * Searches child theme, parent theme, then plugin directories in order.
+     *
+     * @param string $templateName Template filename without extension.
+     * @return string|false Raw HTML content, or false if not found.
+     */
     public static function getEmailTemplateByName($templateName)
     {
         $dirs = self::getEmailTemplateDirectories();
@@ -74,6 +99,13 @@ class Templates
         return false;
     }
 
+    /**
+     * Returns all available email templates with their source label as the display value.
+     *
+     * Deduplicates by template name so child-theme overrides shadow plugin templates.
+     *
+     * @return array<string, string> Map of template name to "Source: name" display string.
+     */
     public static function getArrayOfEmailTemplates(): array
     {
         $templates = [];
@@ -99,11 +131,28 @@ class Templates
         return $templates;
     }
 
+    /**
+     * Returns true if the given template name exists in any of the template directories.
+     *
+     * @param string $emailTemplate Template filename without extension.
+     * @return bool
+     */
     public static function validateEmailTemplate(string $emailTemplate): bool
     {
         return array_key_exists($emailTemplate, self::getArrayOfEmailTemplates());
     }
 
+    /**
+     * Fetches a campaign's email template via REST and archives a copy to disk.
+     *
+     * Archives are stored in email_templates/archived/ so campaign emails can be re-sent
+     * with the exact template snapshot that existed at send time. In test mode the archive
+     * is always refreshed; in production mode it is written only once.
+     *
+     * @param int  $campaignPostId Campaign post ID.
+     * @param bool $testMode       When true, always overwrites the archived copy.
+     * @return string|false Processed template HTML, or false if retrieval failed.
+     */
     public static function copyTemplate(int $campaignPostId, bool $testMode): string|bool
     {
         $templateName = get_post_meta($campaignPostId, 'template', true);
@@ -130,6 +179,12 @@ class Templates
         return $template;
     }
 
+    /**
+     * Resolves a PHP template path using the child-theme → parent-theme → plugin override chain.
+     *
+     * @param string $templatePath Relative path (e.g. 'stats/subscriber-growth.php').
+     * @return string Absolute path to the first matching file, or path to missingTemplate.php.
+     */
     public static function getTemplatePath( string $templatePath ):string {
         $theme_template_paths = array(
             trailingslashit( get_stylesheet_directory() ) .'mawiblah/'. $templatePath , // Child/Active Theme
@@ -146,16 +201,34 @@ class Templates
         return MAWIBLAH_TEMPLATES_PATH. '/missingTemplate.php';
     }
 
+    /**
+     * Includes a PHP template, resolving it through the theme override chain.
+     *
+     * @param string $templatePath Relative path to the template.
+     * @param mixed  $data         Data made available to the template as $data.
+     */
     public static function loadTemplate(string $templatePath, mixed $data) {
         include self::getTemplatePath($templatePath);
     }
 
+    /**
+     * Renders a styled HTML data table using the campaign/table-stats.php partial.
+     *
+     * @param array $headers Column header labels.
+     * @param array $rows    Array of row arrays, each containing one value per column.
+     */
     public static function renderTable(array $headers, array $rows): void
     {
         $data = ['headers' => $headers, 'rows' => $rows];
         self::loadTemplate('campaign/table-stats.php',$data);
     }
 
+    /**
+     * Returns the translated name of a weekday.
+     *
+     * @param string $day English day name (e.g. 'Monday').
+     * @return string Translated day name, or the original string if unrecognised.
+     */
     public static function getDayTranslation($day){
         return match ($day) {
             'Monday' => __('Monday', 'mawiblah'),

--- a/classes/Tests.php
+++ b/classes/Tests.php
@@ -4,16 +4,25 @@ namespace Mawiblah;
 
 class Tests
 {
+    /** Outputs a scenario heading (<h2>) in the test results area. */
     public static function echoHeading(string $title): void
     {
         echo '<h2>' . esc_html($title) . '</h2>';
     }
 
+    /** Outputs an assertion label (<h3>) in the test results area. */
     public static function echoTitle(string $title): void
     {
         echo '<h3>' . esc_html($title) . '</h3>';
     }
 
+    /**
+     * Outputs a pass/fail result line with optional debug dump.
+     *
+     * @param string     $resultMessage Human-readable assertion result.
+     * @param string     $resultType    'success' or 'error' (mapped to CSS class).
+     * @param mixed|null $debug         Optional value to print_r below the result.
+     */
     public static function echoResult(string $resultMessage, string $resultType, $debug = null): void
     {
         echo '<p class="mawiblah-' . esc_attr($resultType) . '">' . esc_html($resultMessage) . '</p>';
@@ -22,6 +31,7 @@ class Tests
         }
     }
 
+    /** Permanently deletes all subscriber posts matching the given email address (test cleanup helper). */
     private static function deleteSubscribersByEmail(string $email): void
     {
         $posts = get_posts([
@@ -35,6 +45,7 @@ class Tests
         }
     }
 
+    /** Returns the map of scenario slug to display label for the test page button grid. */
     public static function scenarios(): array
     {
         return [
@@ -51,6 +62,11 @@ class Tests
         ];
     }
 
+    /**
+     * Dispatches to the named scenario method after verifying administrator capability.
+     *
+     * @param string $scenario Scenario slug from scenarios().
+     */
     public static function run(string $scenario): void
     {
         if (!current_user_can('administrator')) {
@@ -77,6 +93,7 @@ class Tests
     // Campaign CRUD
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: campaign CRUD, hash lookup, uniqueness, and cleanup. */
     public static function campaignScenario(): void
     {
         self::echoHeading('Campaign CRUD');
@@ -123,6 +140,7 @@ class Tests
     // Campaign Workflow
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: campaign test/approve/start/finish workflow state transitions. */
     public static function campaignWorkflowScenario(): void
     {
         self::echoHeading('Campaign Workflow');
@@ -178,6 +196,7 @@ class Tests
     // Campaign Counters
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: campaign counters initialise at zero and update correctly. */
     public static function campaignCountersScenario(): void
     {
         self::echoHeading('Campaign Counters');
@@ -210,6 +229,7 @@ class Tests
     // Campaign Template & Placeholders
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: fillTemplate replaces all placeholders including URL-encoded variants. */
     public static function campaignTemplateScenario(): void
     {
         self::echoHeading('Campaign Template & Placeholders');
@@ -246,6 +266,7 @@ class Tests
     // Subscriber CRUD & Audience Hash
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: subscriber CRUD, audience hash generation, and token idempotency. */
     public static function subscriberScenario(): void
     {
         self::echoHeading('Subscriber CRUD & Audience Hash');
@@ -310,6 +331,7 @@ class Tests
     // Unsubscribe Flow
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: token validation, unsubed flag, audience assignment, and campaign counter. */
     public static function unsubscribeScenario(): void
     {
         self::echoHeading('Unsubscribe Flow');
@@ -351,6 +373,7 @@ class Tests
     // Click Tracking
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: triple-count click tracking (total, unique-per-session, unique-per-user). */
     public static function clickTrackingScenario(): void
     {
         self::echoHeading('Click Tracking (triple-count)');
@@ -409,6 +432,7 @@ class Tests
     // Subscription Form
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: full subscription form flow including honeypot, invalid email, resubscribe, and partial audience overlap. */
     public static function subscriptionFormScenario(): void
     {
         self::echoHeading('Subscription Form');
@@ -491,6 +515,7 @@ class Tests
     // Default Audiences
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: Unsubed and Testers system audiences exist and have correct hashes. */
     public static function defaultAudiencesScenario(): void
     {
         self::echoHeading('Default Audiences');
@@ -527,6 +552,7 @@ class Tests
     // Programmatic Subscribe
     // -------------------------------------------------------------------------
 
+    /** In-browser integration test: mawiblah_subscribe() function, no-duplicate guard, and mawiblah_subscribed action hook. */
     public static function programmaticSubscribeScenario(): void
     {
         self::echoHeading('Programmatic Subscribe');

--- a/classes/Unsubscribe.php
+++ b/classes/Unsubscribe.php
@@ -52,6 +52,59 @@ class Unsubscribe
         }
     }
 
+    /**
+     * REST endpoint for List-Unsubscribe header.
+     * GET  → redirect to the human-readable confirmation page.
+     * POST → RFC 8058 one-click: immediately unsubscribe, no UI.
+     */
+    public static function oneClickEndpoint(\WP_REST_Request $request): \WP_REST_Response
+    {
+        $subscriberHash = sanitize_text_field($request->get_param('subscriber') ?? '');
+        $unsubToken     = sanitize_text_field($request->get_param('token') ?? '');
+        $campaignHash   = sanitize_text_field($request->get_param('campaign') ?? '');
+
+        $subscriber = Subscribers::getSubscriberBySubscriberHash($subscriberHash);
+
+        if (!$subscriber) {
+            return new \WP_REST_Response(['status' => 'not_found'], 404);
+        }
+
+        if ($request->get_method() === 'GET') {
+            $redirectUrl = add_query_arg([
+                'subscriber'  => $subscriberHash,
+                'unsubscribe' => $subscriber->email,
+                'unsubToken'  => $unsubToken,
+                'campaign'    => $campaignHash ?: null,
+            ], get_site_url());
+            wp_redirect(esc_url_raw($redirectUrl));
+            exit;
+        }
+
+        // POST — one-click unsubscribe
+        if ($subscriber->unsubToken !== $unsubToken) {
+            return new \WP_REST_Response(['status' => 'invalid_token'], 403);
+        }
+
+        if (!$subscriber->unsubed) {
+            update_post_meta($subscriber->id, 'unsubed', true);
+            update_post_meta($subscriber->id, 'unsub_time', time());
+
+            $audience = Subscribers::unsubedAudience();
+            if ($audience) {
+                Subscribers::addSubscriberToAudience($subscriber->id, $audience->term_id);
+            }
+
+            if ($campaignHash) {
+                $campaign = Campaigns::getCampaignByHash($campaignHash);
+                if ($campaign) {
+                    Campaigns::incrementNewlyUnsubed($campaign->id);
+                }
+            }
+        }
+
+        return new \WP_REST_Response(['status' => 'ok'], 200);
+    }
+
     public static function unsubscribeLink(string $subscriberHash, string $email)
     {
         return Helpers::trackingParams([

--- a/classes/Unsubscribe.php
+++ b/classes/Unsubscribe.php
@@ -4,6 +4,7 @@ namespace Mawiblah;
 class Unsubscribe
 {
 
+    /** Intercepts unsubscribe URLs on WordPress init and routes to the appropriate handler. */
     public static function init()
     {
         if (isset($_GET['subscriber']) && isset($_GET['unsubscribe'])) {
@@ -20,6 +21,17 @@ class Unsubscribe
         }
     }
 
+    /**
+     * Initiates the unsubscribe flow for a subscriber: generates a token and shows the confirmation page.
+     *
+     * If the email is not in the subscribers list but exists in Gravity Forms, a subscriber record
+     * is created first. Exits after rendering the template.
+     *
+     * @param string      $email          Subscriber email address.
+     * @param string      $subscriberHash Subscriber hash from the URL.
+     * @param string|null $campaignHash   Campaign hash for counter attribution (optional).
+     * @return array Debug data (returned before exit for testing purposes).
+     */
     public static function unsubscribe(string $email, string $subscriberHash, ?string $campaignHash = null): array
     {
         $subscriber = Subscribers::getSubscriber($email);
@@ -111,6 +123,13 @@ class Unsubscribe
         return new \WP_REST_Response(['status' => 'ok'], 200);
     }
 
+    /**
+     * Builds the initial unsubscribe query string (without a token) for embedding in email bodies.
+     *
+     * @param string $subscriberHash Subscriber identifier hash.
+     * @param string $email          Subscriber email address.
+     * @return string Query string starting with '?'.
+     */
     public static function unsubscribeLink(string $subscriberHash, string $email)
     {
         return Helpers::trackingParams([
@@ -119,6 +138,15 @@ class Unsubscribe
         ]);
     }
 
+    /**
+     * Builds the token-bearing confirmation query string shown on the "Are you sure?" page.
+     *
+     * @param string      $subscriberHash Subscriber identifier hash.
+     * @param string      $email          Subscriber email address.
+     * @param string      $unsubToken     One-time unsubscribe verification token.
+     * @param string|null $campaignHash   Campaign hash for counter attribution (optional).
+     * @return string Query string starting with '?'.
+     */
     public static function unsubscribeConfirmLink(string $subscriberHash, string $email, string $unsubToken, ?string $campaignHash = null)
     {
         $params = [
@@ -134,6 +162,18 @@ class Unsubscribe
         return Helpers::trackingParams($params);
     }
 
+    /**
+     * Completes the unsubscribe flow after the subscriber confirms via the token URL.
+     *
+     * Validates the token, marks the subscriber as unsubed, adds them to the Unsubed audience,
+     * stores optional feedback, and increments the campaign's newly-unsubscribed counter.
+     * Exits after rendering the result template.
+     *
+     * @param string      $subscriberHash Subscriber identifier hash.
+     * @param string      $email          Subscriber email address.
+     * @param string      $unsubToken     Token from the confirmation URL.
+     * @param string|null $campaignHash   Campaign hash for counter attribution (optional).
+     */
     public static function unsubscribeAprooved(string $subscriberHash, string $email, string $unsubToken, ?string $campaignHash = null)
     {
         $debug = [

--- a/classes/Unsubscribe.php
+++ b/classes/Unsubscribe.php
@@ -69,7 +69,9 @@ class Unsubscribe
             return new \WP_REST_Response(['status' => 'not_found'], 404);
         }
 
-        if ($request->get_method() === 'GET') {
+        $method = $request->get_method();
+
+        if ($method === 'GET') {
             $redirectUrl = add_query_arg([
                 'subscriber'  => $subscriberHash,
                 'unsubscribe' => $subscriber->email,
@@ -80,7 +82,11 @@ class Unsubscribe
             exit;
         }
 
-        // POST — one-click unsubscribe
+        if ($method !== 'POST') {
+            return new \WP_REST_Response(['status' => 'method_not_allowed'], 405);
+        }
+
+        // POST — one-click unsubscribe (RFC 8058)
         if ($subscriber->unsubToken !== $unsubToken) {
             return new \WP_REST_Response(['status' => 'invalid_token'], 403);
         }

--- a/classes/Visits.php
+++ b/classes/Visits.php
@@ -6,6 +6,8 @@ class Visits
 {
 
     // http://gudlenieks.test/tmp-test/?utm_source=email&utm_medium=email&utm_campaign=monthly-email&campaign=5839ddf15d7eafa3befa98544d2c1e9d&subscriber=f5f96025b4aa949ad6d1b20e207c66c9
+
+    /** Hooks into WordPress init to detect campaign tracking parameters in the URL and record the visit. */
     public static function init()
     {
         if (isset($_GET['campaign']) && isset($_GET['subscriber']) && !isset($_GET['unsubscribe'])) {
@@ -17,6 +19,17 @@ class Visits
         }
     }
 
+    /**
+     * Records a link click for a campaign and subscriber.
+     *
+     * Increments the campaign total-click and per-URL counters and the subscriber activity counter.
+     * Stores campaign/subscriber/URL state in the PHP session so subsequent calls on the same
+     * page load are counted correctly (total always increments; unique-per-session counts only once).
+     *
+     * @param string $campaignHash   Campaign identifier hash.
+     * @param string $subscriberHash Subscriber identifier hash.
+     * @param string $currentUrl     The URL that was visited/clicked.
+     */
     public static function visit(string $campaignHash, string $subscriberHash, $currentUrl): void
     {
         if (!session_id()) {

--- a/mawiblah.php
+++ b/mawiblah.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mawiblah
  * Plugin URI: https://github.com/lauzis/
  * Description: Fff-ine, will build my own mailchimp... with blackjack and hookers.
- * Version: 1.0.17
+ * Version: 1.0.18
  * Author: Aivars Lauzis
  * Author URI: https://github.com/lauzis/
  * License: GPL3 - http://www.gnu.org/licenses/gpl.html
@@ -11,7 +11,7 @@
  */
 
 if (!defined('MAWIBLAH_VERSION')) {
-    define('MAWIBLAH_VERSION', '1.0.17.' . time());
+    define('MAWIBLAH_VERSION', '1.0.18.' . time());
 }
 
 define('MAWIBLAH_PLUGIN_NAME', 'Mawiblah');

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: lauzis
 Tags: email, newsletter, marketing, mailchimp alternative, subscribers
 Requires at least: 5.0
 Tested up to: 6.9
-Stable tag: 1.0.17
+Stable tag: 1.0.18
 Requires PHP: 8.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
@@ -27,6 +27,7 @@ It is not suited for sending out 100k emails. It sends "individual" emails via W
 *   Action logging.
 *   Detailed statistics dashboard (Subscriber growth, Activity rating, etc.).
 *   Native subscription form (shortcode & Gutenberg block) with honeypot + optional reCAPTCHA v3 spam protection.
+*   RFC 8058 List-Unsubscribe headers on campaign emails for one-click unsubscribe in Gmail and other modern mail clients.
 
 **Who is it for?**
 
@@ -67,6 +68,11 @@ Technically yes, but it is not recommended. The plugin sends emails individually
 8. MVP version
 
 == Changelog ==
+
+= 1.0.18 =
+*   New: List-Unsubscribe and List-Unsubscribe-Post headers on campaign emails (RFC 8058 one-click unsubscribe).
+*   New: GET|POST /wp-json/mawiblah/v1/unsubscribe endpoint — POST for mail-client one-click, GET for human redirect.
+*   Fixed: Content-Type: text/html header was missing from campaign emails.
 
 = 1.0.17 =
 *   New: Native subscription form via `[mawiblah_subscribe_form]` shortcode and Gutenberg block.

--- a/templates/settings/fields/text.php
+++ b/templates/settings/fields/text.php
@@ -1,13 +1,13 @@
-<div class="mawiblah-form-field" id="mawiblah-form-field-<?= $id ?>">
+<div class="mawiblah-form-field" id="mawiblah-form-field-<?= esc_attr($id) ?>">
 
-  <label for="<?= $id ?>">
-    <?= $title ?>
+  <label for="<?= esc_attr($id) ?>">
+    <?= esc_html($title) ?>
   </label>
 
-  <input name="<?= $id ?>" id="<?= $id ?>" placeholder="<?= $placeholder ?>" value="<?= $value ? $value : $default_value; ?>" />
+  <input name="<?= esc_attr($id) ?>" id="<?= esc_attr($id) ?>" placeholder="<?= esc_attr($placeholder) ?>" value="<?= esc_attr($value ?: $default_value) ?>" />
 
   <?php if ($description): ?>
-    <p class="mawiblah-form-field-description"><?= $description ?></p>
+    <p class="mawiblah-form-field-description"><?= wp_kses_post($description) ?></p>
   <?php endif; ?>
 
 </div>

--- a/templates/settings/fields/textarea.php
+++ b/templates/settings/fields/textarea.php
@@ -1,18 +1,17 @@
 <div class="mawiblah-form-field" id="mawiblah-form-field-<?= esc_attr($id) ?>">
 
-  <label for="<?= $id ?>">
-    <?= $title ?>
+  <label for="<?= esc_attr($id) ?>">
+    <?= esc_html($title) ?>
   </label>
 
-  <textarea 
-  name="<?= esc_attr($id) ?>" 
-  id="<?= esc_attr($id) ?>" 
-  placeholder="<?= esc_attr($placeholder) ?>" 
-  ><?= esc_textarea($value ? $value : $default_value); ?></textarea>
+  <textarea
+  name="<?= esc_attr($id) ?>"
+  id="<?= esc_attr($id) ?>"
+  placeholder="<?= esc_attr($placeholder) ?>"
+  ><?= esc_textarea($value ?: $default_value) ?></textarea>
 
   <?php if ($description): ?>
--    <p class="mawiblah-form-field-description"><?= $description ?></p>
-+    <p class="mawiblah-form-field-description"><?= esc_html($description) ?></p>
+    <p class="mawiblah-form-field-description"><?= wp_kses_post($description) ?></p>
   <?php endif; ?>
 
 </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RFC 8058 one-click unsubscribe via `List-Unsubscribe` and `List-Unsubscribe-Post`
  * Added REST unsubscribe endpoint: immediate one-click unsubscribe on `POST`, confirmation flow on `GET`
  * Improved subscription form REST handling for honeypot and reCAPTCHA outcomes
* **Bug Fixes**
  * Ensured campaign emails include `Content-Type: text/html; charset=UTF-8`
* **Security**
  * Strengthened settings save flow with nonce verification and input sanitization
  * Hardened settings field templates with consistent escaping
* **Documentation**
  * Updated README/readme.txt and DOCUMENTATION.md (v1.0.18) with unsubscribe behavior and REST endpoint details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->