### PR TITLE
1.0.19 - Block test start when campaign has no testers

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -69,7 +69,9 @@ From creation through test, approval, and final send to all subscribers.
 ```mermaid
 flowchart TD
     A[Admin creates campaign\ntitle · subject · template · audiences] --> B[Campaign saved as WP post]
-    B --> C[testStart\nsets testStarted timestamp]
+    B --> B1{Any testers in\ncampaign audiences?}
+    B1 -- No --> B2[Show error:\nno testers found\nblock test start]
+    B1 -- Yes --> C[testStart\nsets testStarted timestamp]
     C --> D[JS calls REST API per subscriber]
     D --> E{testMode?\ntestStarted AND NOT testApproved}
     E -- Yes --> F{Subscriber is a tester?}

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ The initial version was built by hand. From version 1.0.9 onward, most changes h
 
 ## Change log
 
+### --- 1.0.19 ---
+- **New:** Test start is now blocked when none of the campaign's audiences contain a tester subscriber. A clear error message is shown with a link back to the campaign, preventing an empty test run from being recorded.
+
 ### --- 1.0.18 ---
 - **New:** `List-Unsubscribe` and `List-Unsubscribe-Post: List-Unsubscribe=One-Click` headers added to every campaign email — enables one-click unsubscribe in Gmail, Apple Mail, and other RFC 8058-compliant clients.
 - **New:** `GET|POST /wp-json/mawiblah/v1/unsubscribe` REST endpoint — `POST` immediately unsubscribes (RFC 8058 one-click, used by mail clients); `GET` redirects to the existing confirmation page (used when a human clicks the header link).

--- a/classes/Subscribers.php
+++ b/classes/Subscribers.php
@@ -640,6 +640,25 @@ class Subscribers
         return $testerFlag || $inTesterAudience;
     }
 
+    /**
+     * Returns true if at least one subscriber in any of the given audience IDs is a tester.
+     *
+     * @param int[] $audienceIds Array of audience term IDs to search.
+     * @return bool
+     */
+    public static function hasTestersInAudiences(array $audienceIds): bool
+    {
+        foreach ($audienceIds as $audienceId) {
+            $subscribers = self::getSubscribersByAudience((int) $audienceId);
+            foreach ($subscribers as $subscriber) {
+                if (self::isTester($subscriber)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /** Returns the "Testers" system audience term, creating it if it does not exist. */
     public static function testerAudience()
     {

--- a/mawiblah.php
+++ b/mawiblah.php
@@ -3,7 +3,7 @@
  * Plugin Name: Mawiblah
  * Plugin URI: https://github.com/lauzis/
  * Description: Fff-ine, will build my own mailchimp... with blackjack and hookers.
- * Version: 1.0.18
+ * Version: 1.0.19
  * Author: Aivars Lauzis
  * Author URI: https://github.com/lauzis/
  * License: GPL3 - http://www.gnu.org/licenses/gpl.html
@@ -11,7 +11,7 @@
  */
 
 if (!defined('MAWIBLAH_VERSION')) {
-    define('MAWIBLAH_VERSION', '1.0.18.' . time());
+    define('MAWIBLAH_VERSION', '1.0.19.' . time());
 }
 
 define('MAWIBLAH_PLUGIN_NAME', 'Mawiblah');

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: lauzis
 Tags: email, newsletter, marketing, mailchimp alternative, subscribers
 Requires at least: 5.0
 Tested up to: 6.9
-Stable tag: 1.0.18
+Stable tag: 1.0.19
 Requires PHP: 8.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl.html
@@ -68,6 +68,9 @@ Technically yes, but it is not recommended. The plugin sends emails individually
 8. MVP version
 
 == Changelog ==
+
+= 1.0.19 =
+*   New: Block test start when campaign has no testers — shows a clear error and links back to the campaign edit page.
 
 = 1.0.18 =
 *   New: List-Unsubscribe and List-Unsubscribe-Post headers on campaign emails (RFC 8058 one-click unsubscribe).

--- a/templates/campaign/email-list.php
+++ b/templates/campaign/email-list.php
@@ -54,9 +54,20 @@
             exit;
         }
 
-        Campaigns::testStart($campaignPostId);
-
         $audiences = $campaign->audiences;
+
+        if ($testMode && !Subscribers::hasTestersInAudiences($audiences)) {
+            ?>
+            <div class="alert alert-danger">
+                <strong>Cannot start test</strong>
+                <p>No testers found in the campaign's audiences. Add at least one subscriber to the <strong>Testers</strong> audience before running a test.</p>
+                <a class="btn btn-secondary" href="<?= esc_url(Helpers::generatePluginUrl(['action' => 'campaign-edit', 'campaignPostId' => $campaignPostId])) ?>">Back to campaign</a>
+            </div>
+            <?php
+            exit;
+        }
+
+        Campaigns::testStart($campaignPostId);
         $template = Campaigns::lockTemplate($campaign, $testMode);
 
         $counters = Campaigns::getCounters($campaign);

--- a/tests/Integration/SubscriberTest.php
+++ b/tests/Integration/SubscriberTest.php
@@ -82,6 +82,51 @@ class SubscriberTest extends WP_UnitTestCase
         $this->assertSame($token1, $token2);
     }
 
+    public function test_has_testers_returns_false_with_no_testers(): void
+    {
+        $term = wp_insert_term('No Testers Audience', Subscribers::postType() . '_category');
+        if (is_wp_error($term)) $this->markTestSkipped('Could not create term');
+        $audienceId = $term['term_id'];
+
+        wp_set_object_terms($this->sub->id, $audienceId, Subscribers::postType() . '_category');
+
+        $this->assertFalse(Subscribers::hasTestersInAudiences([$audienceId]));
+
+        wp_delete_term($audienceId, Subscribers::postType() . '_category');
+    }
+
+    public function test_has_testers_returns_true_with_tester_meta(): void
+    {
+        $term = wp_insert_term('Meta Tester Audience', Subscribers::postType() . '_category');
+        if (is_wp_error($term)) $this->markTestSkipped('Could not create term');
+        $audienceId = $term['term_id'];
+
+        wp_set_object_terms($this->sub->id, $audienceId, Subscribers::postType() . '_category');
+        update_post_meta($this->sub->id, 'tester', true);
+
+        $this->assertTrue(Subscribers::hasTestersInAudiences([$audienceId]));
+
+        delete_post_meta($this->sub->id, 'tester');
+        wp_delete_term($audienceId, Subscribers::postType() . '_category');
+    }
+
+    public function test_has_testers_returns_true_via_testers_audience(): void
+    {
+        $testerAudience = Subscribers::testerAudience();
+        $this->assertNotNull($testerAudience);
+
+        wp_set_object_terms($this->sub->id, $testerAudience->term_id, Subscribers::postType() . '_category');
+
+        $this->assertTrue(Subscribers::hasTestersInAudiences([$testerAudience->term_id]));
+
+        wp_remove_object_terms($this->sub->id, $testerAudience->term_id, Subscribers::postType() . '_category');
+    }
+
+    public function test_has_testers_returns_false_for_empty_audience_list(): void
+    {
+        $this->assertFalse(Subscribers::hasTestersInAudiences([]));
+    }
+
     public function test_is_email_sent_flag(): void
     {
         $cId = Campaigns::addCampaign('Sent Flag Test', 'Subj', 'Title', 'Content', [], 'test');


### PR DESCRIPTION
Add Subscribers::hasTestersInAudiences() and guard in email-list.php that shows an error and exits before testStart() when no tester subscribers exist in the campaign's audiences.